### PR TITLE
Revert "OP-2311 - Align maven artifact packaging with existing implementation"

### DIFF
--- a/tooling/.maven/maven_publish.gradle
+++ b/tooling/.maven/maven_publish.gradle
@@ -1,5 +1,4 @@
 apply from: "https://raw.githubusercontent.com/endiosGmbH/Android-Config/master/tooling/.maven/maven.gradle"
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
 
 afterEvaluate {

--- a/version.gradle
+++ b/version.gradle
@@ -29,8 +29,6 @@ version.coil = "1.1.0"
 version.android_gradle_plugin = '4.2.1'
 version.kotlin_coroutines = "1.5.0"
 version.kotlin = "1.5.10"
-// maven artifact packaging
-version.maven_artifact_packaging = "2.1"
 // dependency graph
 version.dependency_graph = "0.5.0"
 // epoxy
@@ -101,7 +99,6 @@ androidx_core.core = "androidx.core:core:$version.androidx_core"
 androidx_core.core_ktx = "androidx.core:core-ktx:$version.androidx_core"
 dependency.androidx_core = androidx_core
 
-dependency.maven_artifact_packaging = "com.github.dcendents:android-maven-gradle-plugin:$version.maven_artifact_packaging"
 dependency.dependency_graph = "com.vanniktech:gradle-dependency-graph-generator-plugin:$version.dependency_graph"
 
 def epoxy = [:]


### PR DESCRIPTION
**Ticket:** [OP-2311](https://endios.atlassian.net/browse/OP-2311 "Link to JIRA")

**Purpose of this Pull Request:**
- Revert #9 changes since we segregate packaging and publishing and apply the packaging plugin in the widget module.

**Additional Note:**
N/A