### PR TITLE
OP-2750 - Align Android gradle dependencies version with the app project

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -4,18 +4,18 @@ ext.dependency = [:]
 def version = [:]
 // start-dependency-version-declaration
 // androidx
-version.androidx_annotation = "1.2.0"
-version.androidx_appcompat = "1.3.0"
-version.androidx_browser = "1.3.0"
+version.androidx_annotation = "1.1.0"
+version.androidx_appcompat = "1.2.0"
+version.androidx_browser = "1.2.0"
 version.androidx_constraint_layout = "2.0.4"
 version.androidx_arch_core = "2.1.0"
-version.androidx_core = "1.6.0"
+version.androidx_core = "1.3.2"
 version.androidx_espresso = "3.4.0"
-version.androidx_navigation = "2.3.5"
-version.androidx_navigation_plugin = "2.3.5"
-version.androidx_lifecycle = "2.3.1"
+version.androidx_navigation = "2.2.2"
+version.androidx_navigation_plugin = "2.0.0"
+version.androidx_lifecycle = "2.2.0"
 version.androidx_lifecycle_extensions = "2.2.0"
-version.androidx_recyclerview = "1.2.1"
+version.androidx_recyclerview = "1.1.1"
 version.androidx_swipe_refresh_layout = "1.1.0"
 version.androidx_test = "1.4.0"
 version.androidx_test_junit = "1.1.3"
@@ -42,11 +42,11 @@ version.firebase_messaging = "19.0.1"
 version.foundation = "4.12.0"
 // google
 version.google_exoplayer = "2.10.4"
-version.google_material = "1.4.0"
+version.google_material = "1.3.0"
 version.google_services = "4.3.3"
 version.google_gson = "2.8.5"
-version.google_maps_utils = "2.2.3"
-version.google_places = "2.4.0"
+version.google_maps_utils = "0.5"
+version.google_places = "2.0.0"
 // jacoco
 version.jacoco = "0.8.4"
 // junit
@@ -56,7 +56,7 @@ version.junit_jupiter_plugin = "1.7.1.1"
 // kohii
 version.kohii = "1.2.0.2011008"
 // koin
-version.koin = "3.0.2"
+version.koin = "2.0.1"
 // mockk
 version.mockk = "1.9.2"
 // okhttp
@@ -64,7 +64,7 @@ version.okhttp = "4.1.0"
 // permission
 version.permission = "4.6.0"
 // play-services
-version.play_services_maps = "17.0.1"
+version.play_services_maps = "17.0.0"
 version.play_services_location = "17.0.0"
 version.play_services_vision = "18.0.0"
 // retrofit
@@ -134,12 +134,13 @@ dependency.image = image
 dependency.jacoco_core = "org.jacoco:org.jacoco.core:$version.jacoco"
 
 def koin = [:]
-koin.android = "io.insert-koin:koin-android:$version.koin"
-koin.android_extensions = "io.insert-koin:koin-android-ext:$version.koin"
-koin.core = "io.insert-koin:koin-core:$version.koin"
-koin.core_extensions = "io.insert-koin:koin-core-ext:$version.koin"
-koin.test = "io.insert-koin:koin-test:$version.koin"
-koin.test_junit4 = "io.insert-koin:koin-test-junit4:$version.koin"
+koin.android = "org.koin:koin-android:$version.koin"
+koin.android_scope = "org.koin:koin-android-scope:$version.koin"
+koin.core = "org.koin:koin-core:$version.koin"
+koin.java = "org.koin:koin-java:$version.koin"
+koin.test = "org.koin:koin-test:$version.koin"
+koin.android_view_model = "org.koin:koin-android-viewmodel:$version.koin"
+koin.androidx_view_model = "org.koin:koin-androidx-viewmodel:$version.koin"
 dependency.koin = koin
 
 def kotlin = [:]


### PR DESCRIPTION
**Ticket:** [OP-2750](https://endios.atlassian.net/browse/OP-2750 "Link to JIRA")

**Purpose of this Pull Request:**
- Align gradle dependencies version related to various Android specific APIs such as `design`, `androidx`, `google play services` & `KoiN DI` with the app project

**Additional Note:**
- Dependencies found using the dependency tree of the app project