### PR TITLE
OP-2634  Events Widget: Android: Deep linking to default maps-app has wrong search phrases/destination

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -39,7 +39,7 @@ version.firebase_crashlytics = "17.2.2"
 version.firebase_crashlytics_gradle = "2.3.0"
 version.firebase_messaging = "19.0.1"
 // foundation
-version.foundation = "4.12.11"
+version.foundation = "4.12.12"
 // google
 version.google_exoplayer = "2.10.4"
 version.google_material = "1.3.0"


### PR DESCRIPTION
**Ticket:** [OP-2634](https://endios.atlassian.net/browse/OP-2634)

**Purpose of this Pull Request:** Increase foundation version

**Additional Note:**

**Deprecations (if any):**
