### PR TITLE
OP-3032 - Align AndroidX UI test dependency with existing usage

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -19,6 +19,7 @@ version.androidx_recyclerview = "1.1.0"
 version.androidx_swipe_refresh_layout = "1.1.0"
 version.androidx_test = "1.4.0"
 version.androidx_test_junit = "1.1.3"
+version.androidx_test_uiautomator = "2.2.0"
 version.androidx_viewpager = "1.0.0"
 version.androidx_viewpager2 = "1.0.0"
 // assertJ
@@ -214,6 +215,7 @@ ui_test.androidx_test_orchestrator = "androidx.test:orchestrator:$version.androi
 ui_test.androidx_test_rules = "androidx.test:rules:$version.androidx_test"
 ui_test.androidx_test_runner = "androidx.test:runner:$version.androidx_test"
 ui_test.androidx_test_junit = "androidx.test.ext:junit:$version.androidx_test_junit"
+ui_test.androidx_uiautomator = "androidx.test.uiautomator:uiautomator:$version.androidx_test_uiautomator"
 dependency.ui_test = ui_test
 
 def ui = [:]


### PR DESCRIPTION
**Ticket:** [OP-3032](https://endios.atlassian.net/browse/OP-3032 "Link to JIRA")

**Purpose of this Pull Request:**
- Align AndroidX UI test dependency with existing usage
 
**Additional Note:**
N/A

**Deprecations (if any):**
N/A