### PR TITLE
OP-5637 Push notifications crash on Android 12

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -38,7 +38,7 @@ version.epoxy = "4.6.3"
 version.firebase_core = "21.0.0"
 version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
-version.firebase_messaging = "19.0.1"
+version.firebase_messaging = "23.0.7"
 // foundation
 version.foundation = "4.26.18"
 // google


### PR DESCRIPTION
**Ticket:** [OP-5637](https://endios.atlassian.net/browse/OP-5637)

**Purpose of this Pull Request:** Increase firebase messaging version to fix bug in Android 12

**Additional Note:**

**Deprecations (if any):**
