### PR TITLE
OP-8630: Update detekt pre commit

### DIFF
--- a/tooling/hooks/pre-commit
+++ b/tooling/hooks/pre-commit
@@ -30,7 +30,7 @@ function ktlint_check() {
 }
 
 function detekt_check() {
-  echo $git_diff | xargs echo | tr ' ' ',' | tr ' ' ',' | xargs /usr/local/bin/detekt-cli-1.22.0/bin/detekt-cli --config tooling/.detekt/detekt-config.yml --input
+  echo $git_diff | xargs echo | tr ' ' ',' | tr ' ' ',' | xargs /usr/local/bin/detekt-cli-1.22.0/bin/detekt-cli --config tooling/.detekt/detekt-config.yml -p tooling/.detekt/detekt-formatting-1.22.0.jar --input
 }
 
 echo


### PR DESCRIPTION
**Ticket:** [OP-8630](https://endios.atlassian.net/browse/OP-8630 "Link to JIRA")

**Purpose of this Pull Request:**
- Update `detekt pre-commit` to indicate to use the format `detekt-formatting-1.22.0.jar`; this fix `property 'formatting' is misspelled` issue in `pre-commit`


[OP-8630]: https://endios.atlassian.net/browse/OP-8630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ