### PR TITLE
OP-11671 Mark-E crashes because UserCredentials value is null

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -42,7 +42,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation
-version.foundation = "4.28.24"
+version.foundation = "4.28.25"
 version.one_core_compose = "4.26.58"
 // google
 version.google_exoplayer = "2.17.1"


### PR DESCRIPTION
**Ticket:** [OP-11671](https://endios.atlassian.net/browse/OP-11671)

**Purpose of this Pull Request:** Increase foundation version

[OP-11671]: https://endios.atlassian.net/browse/OP-11671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ