### PR TITLE
OP-8881 [Foundation][Android][ALL Widgets] Migrate Koin dependency to version 3

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -31,7 +31,7 @@ version.android_gradle_plugin = '8.0.1'
 version.kotlin_coroutines = "1.7.1"
 // When updating please update compose_kotlin_compiler too
 // see https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-version.kotlin = "1.8.21"
+version.kotlin = "1.9.0"
 // dependency graph
 version.dependency_graph = "0.8.0"
 // work manager
@@ -79,7 +79,7 @@ version.retrofit = "2.6.1"
 // vertx-codegen
 version.vertx_codegen = "3.6.0"
 // jetpack-compose
-version.compose_kotlin_compiler = "1.4.7"
+version.compose_kotlin_compiler = "1.5.0"
 version.compose_activity = "1.7.1"
 version.compose_lifecycle_viewmodel = "2.5.1"
 version.compose_base = "1.5.4"

--- a/version.gradle
+++ b/version.gradle
@@ -42,7 +42,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation
-version.foundation = "4.28.31"
+version.foundation = "4.29.0"
 version.one_core_compose = "4.26.58"
 // google
 version.google_exoplayer = "2.17.1"
@@ -152,7 +152,6 @@ koin.android = "io.insert-koin:koin-android:$version.koin"
 koin.android_scope = "io.insert-koin:koin-android-scope:$version.koin"
 koin.core = "io.insert-koin:koin-core:$version.koin"
 koin.test = "io.insert-koin:koin-test:$version.koin"
-//koin.androidx_view_model = "io.insert-koin:koin-androidx-viewmodel:$version.koin"
 dependency.koin = koin
 
 def kotlin = [:]

--- a/version.gradle
+++ b/version.gradle
@@ -27,7 +27,7 @@ version.assertj = "3.10.0"
 // coil
 version.coil = "2.4.0"
 // core
-version.android_gradle_plugin = '8.0.1'
+version.android_gradle_plugin = '8.3.0'
 version.kotlin_coroutines = "1.8.0"
 // When updating please update compose_kotlin_compiler too
 // see https://developer.android.com/jetpack/androidx/releases/compose-kotlin

--- a/version.gradle
+++ b/version.gradle
@@ -64,7 +64,7 @@ version.core_ktx = "1.5.0"
 // kohii
 version.kohii = "1.4.0.2017001"
 // koin
-version.koin = "3.5.3"
+version.koin = "4.0.0"
 // mockk
 version.mockk = "1.13.5"
 // okhttp

--- a/version.gradle
+++ b/version.gradle
@@ -28,7 +28,7 @@ version.assertj = "3.10.0"
 version.coil = "2.4.0"
 // core
 version.android_gradle_plugin = '8.0.1'
-version.kotlin_coroutines = "1.9.0"
+version.kotlin_coroutines = "1.8.0"
 // When updating please update compose_kotlin_compiler too
 // see https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 version.kotlin = "1.9.0"

--- a/version.gradle
+++ b/version.gradle
@@ -64,7 +64,7 @@ version.core_ktx = "1.5.0"
 // kohii
 version.kohii = "1.4.0.2017001"
 // koin
-version.koin = "2.2.3"
+version.koin = "3.5.3"
 // mockk
 version.mockk = "1.13.5"
 // okhttp

--- a/version.gradle
+++ b/version.gradle
@@ -28,7 +28,7 @@ version.assertj = "3.10.0"
 version.coil = "2.4.0"
 // core
 version.android_gradle_plugin = '8.0.1'
-version.kotlin_coroutines = "1.7.1"
+version.kotlin_coroutines = "1.9.0"
 // When updating please update compose_kotlin_compiler too
 // see https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 version.kotlin = "1.9.0"

--- a/version.gradle
+++ b/version.gradle
@@ -152,7 +152,7 @@ koin.android = "io.insert-koin:koin-android:$version.koin"
 koin.android_scope = "io.insert-koin:koin-android-scope:$version.koin"
 koin.core = "io.insert-koin:koin-core:$version.koin"
 koin.test = "io.insert-koin:koin-test:$version.koin"
-koin.androidx_view_model = "io.insert-koin:koin-androidx-viewmodel:$version.koin"
+//koin.androidx_view_model = "io.insert-koin:koin-androidx-viewmodel:$version.koin"
 dependency.koin = koin
 
 def kotlin = [:]


### PR DESCRIPTION
**Ticket:** [OP-8881](https://endios.atlassian.net/browse/OP-8881)

**Purpose of this Pull Request:** Upgrade KOIN to 4.0.0

After this is merged a lot of widgets will be broken but the fixes are already pending.


[OP-8881]: https://endios.atlassian.net/browse/OP-8881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ