### PR TITLE
OP-15714 [Android][Config] Auth analytics missing widget information

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.24"
+version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
-version.foundation_auth = "5.0.31"
+version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
-version.foundation_auth = "5.0.32"
+version.foundation_auth = "5.0.31"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- `version.foundation`: `5.3.24` → `5.3.25`
- `version.foundation_auth`: `5.0.31` → `5.0.32`

## Companion PRs
- Foundation interface: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/775
- Auth implementation: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/41

## Test plan
- Trigger login from widget tile → verify `widget_id`, `widget_name`, `widget_type` present in Firebase DebugView
- Trigger login from deeplink/session expiry → verify no crash and widget fields are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)