### PR TITLE
OP-15714 Bump foundation_auth to 5.0.32

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
-version.foundation_auth = "5.0.31"
+version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_auth` from `5.0.31` to `5.0.32`
- Auth module `5.0.32` includes the fix for OP-15714: auth analytics events now include `widget_id`, `widget_name`, and `widget_type` fields

## Test plan
- [ ] Verify `developDebug` build resolves `platform-auth:5.0.32` from Maven
- [ ] Verify auth analytics events include widget fields when triggered from a widget tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)