### PR TITLE
OP-15370: Overlay analytics

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 // todo restore me before merging to develop
-version.foundation = "5.3.18-overlays-v1.3"
+version.foundation = "5.3.19-overlays-v1.3"
 //version.foundation = "5.3.21"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"


### PR DESCRIPTION
Bump `version.foundation` to `5.3.19-overlays-v1.3` to match foundation changes in OP-15370.