### PR TITLE
OP-15787 [Android][Config] Bump foundation to 5.3.26 and auth to 5.0.33

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.25"
+version.foundation = "5.3.26"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.32"
+version.foundation_auth = "5.0.33"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `version.foundation` from 5.3.25 to 5.3.26 (account deletion analytics)
- Bump `version.foundation_auth` from 5.0.32 to 5.0.33 (complete missing auth analytics events)

## Companion PRs
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/43
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/782
- Widget ProfilePremium: https://github.com/endiosGmbH/oneWidgetProfilePremium-Android/pull/141

## Test plan
- [ ] Verify app builds with new versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)