### PR TITLE
OP-15370 - bump foundation version to 5.3.22-overlays-v1.3

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 // todo restore me before merging to develop
-version.foundation = "5.3.21-overlays-v1.3"
+version.foundation = "5.3.22-overlays-v1.3"
 //version.foundation = "5.3.21"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` from `5.3.21-overlays-v1.3` to `5.3.22-overlays-v1.3`

## Test plan
- [ ] Verify dependent projects resolve the correct foundation version

🤖 Generated with [Claude Code](https://claude.com/claude-code)