### PR TITLE
Bump version.foundation to 5.3.27

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.26"
+version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.33"


### PR DESCRIPTION
## Summary
- Update `version.foundation` from `5.3.26` to `5.3.27` to match the current Foundation project `pomVersion`

## Test plan
- [ ] Verify the app builds successfully with the new foundation version
- [ ] Run smoke tests to confirm no regressions from the foundation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)