### PR TITLE
Bump version.foundation_auth to 5.0.34

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.33"
+version.foundation_auth = "5.0.34"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `version.foundation_auth` from 5.0.33 to 5.0.34

## Test plan
- [ ] Verify build succeeds with the updated dependency version

🤖 Generated with [Claude Code](https://claude.com/claude-code)