### PR TITLE
OP-15665 [Config] Bump Foundation version to 5.4.0

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.27"
+version.foundation = "5.4.0"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` from 5.3.27 to 5.4.0 for the OW v2.0 detail view adjustments

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/788

## Test plan
- [ ] Verify all widget repos compile against Foundation 5.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)