### PR TITLE
OP-15112 Bump Foundation LATEST version to 5.4.3

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.27"
+version.foundation = "5.3.28"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` (LATEST) from `5.3.27` to `5.3.28`
- Includes OP-15112: fix for cropped x-axis labels on bar charts (Samsung clipping fix)

## Test plan
- [ ] Verify dev branches pick up Foundation 5.3.28
- [ ] Release branches remain on `foundation_release = 5.3.25` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)