### PR TITLE
OP-15681 [Config] Bump Foundation version to 5.4.1

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.0"
+version.foundation = "5.4.1"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` from `5.4.0` to `5.4.1` to pick up the dynamic status bar text fix (OP-15681)

## Test plan
- [ ] Verify widgets resolve foundation 5.4.1 correctly
- [ ] Confirm status bar fix is included in the resolved foundation artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)