### PR TITLE
OP-15715 Bump version.foundation to 5.4.2

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.0"
+version.foundation = "5.4.2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` from `5.4.0` to `5.4.2` to match the latest Foundation pomVersion on `feature/OP-15715`

## Test plan
- [ ] Verify widget repos on develop pick up the correct Foundation version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)