### PR TITLE
OP-15916 [Config] Bump foundation_auth to 5.0.35

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.34"
+version.foundation_auth = "5.0.35"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_auth` from `5.0.34` to `5.0.35` to pick up autologin after forced password change (OP-15916)

## Test plan
- [ ] Verify widgets resolve foundation-auth 5.0.35 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)