### PR TITLE
OP-15715 Bump version.foundation_release to 5.3.28-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.27-RC"
+version.foundation_release = "5.3.28-RC"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_release` from `5.3.27-RC` to `5.3.28-RC` to match the latest Foundation pomVersion on `release/OP-15715`

## Test plan
- [ ] Verify release branch builds pick up the correct Foundation version after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)