### PR TITLE
OP-15632 [Config] Bump Foundation to 5.4.4

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.3"
+version.foundation = "5.4.4"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.35"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` from `5.4.3` to `5.4.4` to pick up DynamicFormRadioGroup selection fix and app-rating mapper fix (OP-15632)

## Test plan
- [ ] Verify widgets resolve foundation 5.4.4 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)