### PR TITLE
fix(OP-15917): bump foundation version to 5.4.5

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.3"
+version.foundation = "5.4.5"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.35"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` from 5.4.3 to 5.4.5 on develop
- Required after merging OP-15917 (COMBO dropdown key fix) into Foundation

## Linked Tickets
- [OP-15917](https://endios.atlassian.net/browse/OP-15917)

## Checklist
- [ ] Foundation PR merged first: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-15917]: https://endios.atlassian.net/browse/OP-15917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ