### PR TITLE
OP-15787 Bump foundation auth version to 5.0.36

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.4"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.35"
+version.foundation_auth = "5.0.36"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `version.foundation_auth` from 5.0.35 to 5.0.36 on develop
- Required after merging OP-15787 (fix duplicate webview login success events) into Auth

## Linked Tickets
- [OP-15787](https://endios.atlassian.net/browse/OP-15787)

## Checklist
- [ ] Auth PR merged first: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-15787]: https://endios.atlassian.net/browse/OP-15787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ