### PR TITLE
OP-15787 Bump version.foundation to 5.4.7

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.36"
+version.foundation_auth = "5.0.37"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.5"
+version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.36"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` from 5.4.5 to 5.4.7 (LATEST) for account deletion widget info changes

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/798

## Test plan
- [ ] Verify widgets resolve Foundation 5.4.7 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)