### PR TITLE
OP-16024 Bump Auth to 5.0.38

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.37"
+version.foundation_auth = "5.0.38"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
**Ticket:** [OP-16024](https://endios.atlassian.net/browse/OP-16024)

**Purpose of this Pull Request:**
- Bump `version.foundation_auth` from 5.0.37 to 5.0.38 (adds OAuth/PKCE registration analytics events)

**Additional Note:**
- Merge AFTER Auth PR is merged and published
- Companion PRs:
  - Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/51
  - Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/799
  - Foundation version bump: https://github.com/endiosGmbH/Android-Config/pull/649

[OP-16024]: https://endios.atlassian.net/browse/OP-16024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ