### PR TITLE
OP-15032 Bump foundation LATEST to 5.4.9

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.8"
+version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.38"


### PR DESCRIPTION
## Summary

Bump `version.foundation` (LATEST) from `5.4.8` → `5.4.9`.

## Companion PRs

- endiosOneFoundation-Android#801 — Gate overlays on Initial Consent flow (OP-15032)

## Test plan

- [ ] CI green
- [ ] Consumers on LATEST pick up 5.4.9 without issue