### PR TITLE
OP-15821 [Android] Bump foundation_auth to 5.0.39

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.8"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.38"
+version.foundation_auth = "5.0.39"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
Bump \`version.foundation_auth\` from 5.0.38 → 5.0.39 to pick up the fix in endiosGmbH/endiosOneFoundation-Auth-Android#52, which routes the password-recovery connector to the v2 integration (fixes 501 Not Implemented on \`LOAD_AUTHENTICATION\`).

Draft until #52 is merged and 5.0.39 is actually published.

## Test plan
- [ ] Ready to merge once endiosOneFoundation-Auth-Android#52 is merged and artifact 5.0.39 is available from the Maven repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)