### PR TITLE
OP-15916 Bump foundation_auth to 5.0.40

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.39"
+version.foundation_auth = "5.0.40"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `version.foundation_auth` from 5.0.39 to 5.0.40 to pick up the fix/OP-15916 changes in foundation-auth.

## Test plan
- [ ] Merge after endiosGmbH/endiosOneFoundation-Auth-Android#53 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)