### PR TITLE
OP-15032 Bump foundation_release to 5.3.29-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.28-RC"
+version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Companion to [endiosOneFoundation-Android#802](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/802)
- Bumps `version.foundation_release` from `5.3.28-RC` to `5.3.29-RC` to pick up the overlay-order fix for the Initial Consent flow (overlays v1.3)

## Companion PRs
- [endiosOneFoundation-Android#802](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/802) — Gate overlays on Initial Consent flow (v1.3 release fix)

## Test plan
- [ ] Merge Foundation PR #802 first, wait for Maven publish
- [ ] Merge this PR, verify downstream apps resolve `5.3.29-RC`