### PR TITLE
OP-16092 Bump foundation to 5.4.10

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.9"
+version.foundation = "5.4.10"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.39"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` from `5.4.9` to `5.4.10`

## Dependencies
- Requires [endiosOneFoundation-Android#803](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/803) to be merged and published first

🤖 Generated with [Claude Code](https://claude.com/claude-code)