### PR TITLE
Release v26.03

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -34,6 +34,7 @@ version.coil = "2.4.0"
 // core
 version.android_gradle_plugin = '8.11.2'
 version.kotlin_coroutines = "1.9.0"
+version.kotlin_serialization = "1.9.0"
 // When updating please update compose_kotlin_compiler too
 // see https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 version.kotlin = "2.2.0"
@@ -75,7 +76,7 @@ version.core_ktx = "1.5.0"
 // kohii
 version.kohii = "1.4.0.2017001"
 // koin
-version.koin = "4.0.0"
+version.koin = "4.1.1"
 // mockk
 version.mockk = "1.13.5"
 // okhttp
@@ -186,6 +187,7 @@ dependency.jacoco_core = "org.jacoco:org.jacoco.core:$version.jacoco"
 def koin = [:]
 koin.android = "io.insert-koin:koin-android:$version.koin"
 koin.android_scope = "io.insert-koin:koin-android-scope:$version.koin"
+koin.compose = "io.insert-koin:koin-androidx-compose:$version.koin"
 koin.core = "io.insert-koin:koin-core:$version.koin"
 koin.test = "io.insert-koin:koin-test:$version.koin"
 dependency.koin = koin
@@ -196,6 +198,7 @@ kotlin.test = "org.jetbrains.kotlin:kotlin-test-junit:$version.kotlin"
 kotlin.plugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$version.kotlin"
 kotlin.reflect = "org.jetbrains.kotlin:kotlin-reflect:$version.kotlin"
 kotlin.compose_plugin = "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$version.kotlin"
+kotlin.serialization_plugin = "org.jetbrains.kotlin:kotlin-serialization:$version.kotlin"
 dependency.kotlin = kotlin
 
 def kotlin_coroutines = [:]
@@ -203,6 +206,10 @@ kotlin_coroutines.android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$v
 kotlin_coroutines.core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version.kotlin_coroutines"
 kotlin_coroutines.test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$version.kotlin_coroutines"
 dependency.kotlin_coroutines = kotlin_coroutines
+
+def kotlin_serialization = [:]
+kotlin_serialization.json = "org.jetbrains.kotlinx:kotlinx-serialization-json:$version.kotlin_serialization"
+dependency.kotlin_serialization = kotlin_serialization
 
 def lifecycle = [:]
 lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$version.androidx_lifecycle"
@@ -223,6 +230,7 @@ navigation.androidx_navigation_safe_args_plugin = "androidx.navigation:navigatio
 navigation.androidx_navigation_fragment_ktx = "androidx.navigation:navigation-fragment-ktx:$version.androidx_navigation"
 navigation.androidx_navigation_ui_ktx = "androidx.navigation:navigation-ui-ktx:$version.androidx_navigation"
 navigation.androidx_navigation_runtime_ktx = "androidx.navigation:navigation-runtime-ktx:$version.androidx_navigation"
+navigation.androidx_navigation_compose = "androidx.navigation:navigation-compose:$version.androidx_navigation"
 dependency.navigation = navigation
 
 def network = [:]

--- a/version.gradle
+++ b/version.gradle
@@ -131,8 +131,8 @@ if (isReleaseBranch()) {
 def build_version = [:]
 // start-build-version-declaration
 build_version.min_sdk = 26
-build_version.compile_sdk = 35
-build_version.target_sdk = 35
+build_version.compile_sdk = 36
+build_version.target_sdk = 36
 // end-build-version-declaration
 ext.build_version = build_version
 

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.21"
+version.foundation = "5.3.22"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
 version.foundation_auth = "5.0.31"

--- a/version.gradle
+++ b/version.gradle
@@ -219,6 +219,7 @@ lifecycle.runtime = "androidx.lifecycle:lifecycle-runtime:$version.androidx_life
 lifecycle.livedata_ktx = "androidx.lifecycle:lifecycle-livedata-ktx:$version.androidx_lifecycle"
 lifecycle.runtime_ktx = "androidx.lifecycle:lifecycle-runtime-ktx:$version.androidx_lifecycle"
 lifecycle.viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version.androidx_lifecycle"
+lifecycle.navigation = "androidx.lifecycle:lifecycle-viewmodel-navigation3:$version.androidx_lifecycle"
 dependency.lifecycle = lifecycle
 
 def mockk = [:]

--- a/version.gradle
+++ b/version.gradle
@@ -16,6 +16,7 @@ version.androidx_arch_core = "2.1.0"
 version.androidx_core = "1.8.0"
 version.androidx_espresso = "3.3.0"
 version.androidx_navigation = "2.2.2"
+version.androidx_navigation3 = "1.0.0"
 version.androidx_navigation_plugin = "2.9.5"
 version.androidx_lifecycle = "2.4.1"
 version.androidx_lifecycle_extensions = "2.2.0"
@@ -230,8 +231,12 @@ navigation.androidx_navigation_safe_args_plugin = "androidx.navigation:navigatio
 navigation.androidx_navigation_fragment_ktx = "androidx.navigation:navigation-fragment-ktx:$version.androidx_navigation"
 navigation.androidx_navigation_ui_ktx = "androidx.navigation:navigation-ui-ktx:$version.androidx_navigation"
 navigation.androidx_navigation_runtime_ktx = "androidx.navigation:navigation-runtime-ktx:$version.androidx_navigation"
-navigation.androidx_navigation_compose = "androidx.navigation:navigation-compose:$version.androidx_navigation"
 dependency.navigation = navigation
+
+def navigation3 = [:]
+navigation3.runtime = "androidx.navigation3:navigation3-runtime:$version.androidx_navigation3"
+navigation3.ui = "androidx.navigation3:navigation3-ui:$version.androidx_navigation3"
+dependency.navigation3 = navigation3
 
 def network = [:]
 network.browser = "androidx.browser:browser:$version.androidx_browser"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.20"
+version.foundation = "5.3.21"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
 version.foundation_auth = "5.0.31"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.19"
+version.foundation = "5.3.20"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
 version.foundation_auth = "5.0.31"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.22"
+version.foundation = "5.3.23"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
 version.foundation_auth = "5.0.31"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
-version.foundation_auth = "5.0.31"
+version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.27-RC"
+version.foundation_release = "5.3.28-RC"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.23"
+version.foundation = "5.3.24"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
 version.foundation_auth = "5.0.31"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.24"
+version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
-version.foundation_auth = "5.0.31"
+version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.7-RC"
-version.foundation_auth = "5.0.32"
+version.foundation_auth = "5.0.31"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.26-RC"
+version.foundation_release = "5.3.27-RC"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.25"
+version.foundation_release = "5.3.26-RC"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.7-RC"
+version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.28-RC"
+version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Release v26.03

### Changes
- Bump foundation to 5.3.25, foundation_release to 5.3.29-RC, foundation_auth to 5.0.32
- Bump Koin to 4.1.1
- Bump compile/target SDK to 36
- Add Navigation3, Kotlin Serialization, Koin Compose dependencies
- Add lifecycle.navigation dependency