### PR TITLE
OP-16092 Bump foundation to 5.4.11

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.10"
+version.foundation = "5.4.11"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.40"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` from `5.4.10` → `5.4.11` so consumers pick up the Gallery tile empty/error state layout fix shipped in [endiosOneFoundation-Android#807](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/807).

## Ticket
[OP-16092](https://endios.atlassian.net/browse/OP-16092)

## Test plan
- [ ] Merges in order: [endiosOneFoundation-Android#807](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/807) → this PR → [endiosOneFoundation-Check-Android#18](https://github.com/endiosGmbH/endiosOneFoundation-Check-Android/pull/18).
- [ ] No other changes in this PR; artifact bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-16092]: https://endios.atlassian.net/browse/OP-16092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ