### PR TITLE
OP-15821 Bump foundation_auth 5.0.40 → 5.0.41

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.10"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.40"
+version.foundation_auth = "5.0.41"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `foundation_auth` version to 5.0.41 to pick up password recovery QA fixes

Depends on: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)