### PR TITLE
OP-15787 Bump version.foundation to 5.4.13 and foundation_auth to 5.0.41

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.13"
+version.foundation = "5.4.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.41"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.12"
+version.foundation = "5.4.13"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.40"
+version.foundation_auth = "5.0.41"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `version.foundation` 5.4.12 → 5.4.13 (duplicate deletion event fix)
- Bump `version.foundation_auth` 5.0.40 → 5.0.41 (contract redirect analytics fix)

## Companion PRs
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/58
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/810
- ProfilePremium: https://github.com/endiosGmbH/oneWidgetProfilePremium-Android/pull/148

## Test plan
- [ ] Build apps with updated versions and run QA round 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)