### PR TITLE
OP-15787 Bump foundation_auth to 5.0.42

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.41"
+version.foundation_auth = "5.0.42"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Companion PR for [Auth PR #60](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/60)
- Bumps `version.foundation_auth` from 5.0.41 to 5.0.42

## Companion PRs
- [Auth PR #60](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/60) — Add conversion_success analytics on 307 redirect path

## Test plan
- Merge after Auth PR #60 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)