### PR TITLE
OP-16189 Bump version.foundation_auth to 5.0.43-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.34"
+version.foundation_auth = "5.0.35"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.8"
+version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.38"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.10"
+version.foundation = "5.4.11"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.7"
+version.foundation = "5.4.8"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.37"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.11"
+version.foundation = "5.4.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.42"
+version.foundation_auth = "5.0.43-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.13"
+version.foundation = "5.4.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.41"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.26"
+version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.33"

--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.foundation = "5.4.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.40"
-version.foundation_test_library = "5.0.8"
+version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google
 version.google_exoplayer = "2.17.1"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.4"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.35"
+version.foundation_auth = "5.0.36"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.41"
+version.foundation_auth = "5.0.42"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.8"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.37"
+version.foundation_auth = "5.0.36"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.0"
+version.foundation = "5.4.2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.25"
+version.foundation = "5.3.26"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.32"
+version.foundation_auth = "5.0.33"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.0"
+version.foundation = "5.4.1"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.12"
+version.foundation = "5.4.13"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.40"
+version.foundation_auth = "5.0.41"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.33"
+version.foundation_auth = "5.0.34"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.37"
+version.foundation_auth = "5.0.38"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.3"
+version.foundation = "5.4.5"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.35"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.36"
+version.foundation_auth = "5.0.37"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.38"
+version.foundation_auth = "5.0.39"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.9"
+version.foundation = "5.4.10"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.5"
+version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.36"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.40"
+version.foundation_auth = "5.0.41"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.27"
+version.foundation = "5.3.28"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.3"
+version.foundation = "5.4.4"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.35"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.10"
+version.foundation = "5.4.11"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.34"
+version.foundation_auth = "5.0.35"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.39"
+version.foundation_auth = "5.0.40"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.7-RC"
+version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.5"
+version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.36"
+version.foundation_auth = "5.0.37"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.27"
+version.foundation = "5.4.0"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_auth` from `5.0.42` to `5.0.43-RC`
- Merge AFTER Auth PR is published

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/811
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/62
- Android-Config (Foundation version): https://github.com/endiosGmbH/Android-Config/pull/666

## Merge order
1. Foundation #811 → publish
2. Android-Config #666 (Foundation version bump)
3. Auth #62 → publish
4. **This PR** (Auth version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)