### PR TITLE
OP-16189 Bump version.foundation_release to 5.3.30-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.4.13"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.29-RC"
+version.foundation_release = "5.3.30-RC"
 version.foundation_auth = "5.0.40"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_release` from `5.3.29-RC` to `5.3.30-RC`
- Merge AFTER Foundation #811 is published

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/811
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/62

## Merge order
1. Foundation #811 → publish `5.3.30-RC`
2. **This PR**
3. Auth #62 → publish `5.0.43-RC`
4. Android-Config auth version bump (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)