### PR TITLE
OP-16189 Bump version.foundation_auth to 5.0.43-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.13"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.40"
+version.foundation_auth = "5.0.43-RC"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_auth` from `5.0.40` to `5.0.43-RC`
- Merge AFTER Auth #62 is published

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/811
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/62
- Android-Config (Foundation version): https://github.com/endiosGmbH/Android-Config/pull/668

## Merge order
1. Foundation #811 → publish `5.3.30-RC`
2. Android-Config #668 (Foundation version bump)
3. Auth #62 → publish `5.0.43-RC`
4. **This PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)