### PR TITLE
OP-16196 Bump Foundation version to 5.4.15

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.14"
+version.foundation = "5.4.15"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.42"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) from 5.4.14 to 5.4.15
- Companion to endiosOneFoundation-Android [#814](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/814)

## Companion PRs
- Foundation fix: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/814

## Test plan
- [ ] Verify app builds with updated Foundation version

🤖 Generated with [Claude Code](https://claude.com/claude-code)