### PR TITLE
OP-16196 Bump Foundation release version to 5.3.31-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.4.13"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.30-RC"
+version.foundation_release = "5.3.31-RC"
 version.foundation_auth = "5.0.43-RC"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_release` (STABLE) from 5.3.30-RC to 5.3.31-RC

## Companion PRs
- Foundation fix (master): https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/813

## Test plan
- [ ] Verify production apps build with updated Foundation release version

🤖 Generated with [Claude Code](https://claude.com/claude-code)