### PR TITLE
OP-16092 Bump Foundation version to 5.4.16

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.15"
+version.foundation = "5.4.16"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.42"


### PR DESCRIPTION
## Summary

Bumps `version.foundation` from `5.4.15` → `5.4.16` so consumers pick up the Gallery tile chevron clip fix from [endiosOneFoundation-Android#812](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/812).

## Test plan

- [ ] Consumer apps resolving `version.foundation` pick up 5.4.16 from mavenLocal/SFTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)