### PR TITLE
OP-15821 Bump foundation_auth to 5.0.43

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.16"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.42"
+version.foundation_auth = "5.0.43"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Pairs with [endiosOneFoundation-Auth-Android PR #65](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/65).
- The `5.0.42` artifact on Maven was published 2026-04-21 (via OP-15787's pomVersion bump). OP-15821 round-2 fixes (error/success dialogs, 1-step flow) merged on 2026-04-23 without a fresh pomVersion bump, so consumers resolving `foundation_auth = 5.0.42` still receive the pre-round-2 binary.
- Pointing develop to `5.0.43` so endiosOneApp builds from develop pick up the round-2 source once Auth PR #65 merges and publishes.

## Test plan
- [ ] Merge **after** Auth PR #65 is merged and `5.0.43` is available in the Maven repo.
- [ ] Rebuild Herborn test app from `endiosOneApp-Android/develop`; verify Tiep's three round-2 findings (error dialog on auth, success dialog on recovery, 1-step flow when `numberOfRecoverySteps == 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)