### PR TITLE
OP-16034 Bump version.foundation to 5.4.17

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.16"
+version.foundation = "5.4.17"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.43"


### PR DESCRIPTION
## Summary
- Pairs with [endiosOneFoundation-Android PR #816](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/816) — `GalleryBox` placeholder on image load failure.
- Bumps `version.foundation` from `5.4.16` to `5.4.17`. No change to `version.foundation_release` (STABLE).

## Test plan
- [ ] Merge **after** Foundation PR #816 is merged and `5.4.17` is available in the Maven repo.
- [ ] endiosOneApp-Android consumers rebuilt from `develop` transitively pick up Foundation `5.4.17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)