### PR TITLE
OP-16058 Bump version.foundation to 5.4.18

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.17"
+version.foundation = "5.4.18"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.43"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.16"
+version.foundation = "5.4.17"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.43"


### PR DESCRIPTION
**Ticket:** [OP-16058](https://endios.atlassian.net/browse/OP-16058 "Link to JIRA")

**Purpose of this Pull Request:**

Bump `version.foundation` (LATEST) from 5.4.17 to 5.4.18 to match the new Foundation release that adds Firebase parameter-value truncation to `TrackBundle.toBundle()`.

Companion of [endiosOneFoundation-Android#817](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/817).

**Additional Note:**

5.4.17 was originally targeted, but OP-16034 merged into Foundation `develop` first and claimed that slot. Foundation PR #817 was rebased to 5.4.18 and this companion follows suit. Merged develop in to resolve the resulting `version.gradle` conflict (develop already at 5.4.17).

Only `version.foundation` (LATEST) is changed. `version.foundation_release` (STABLE) is untouched.

**Deprecations (if any):**

None.

[OP-16058]: https://endios.atlassian.net/browse/OP-16058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ