### PR TITLE
OP-16151 Bump version.foundation to 5.4.19

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.18"
+version.foundation = "5.4.19"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.43"


### PR DESCRIPTION
**Ticket:** [OP-16151](https://endios.atlassian.net/browse/OP-16151 "Link to JIRA")

**Purpose of this Pull Request:**

Bump `version.foundation` from `5.4.18` → `5.4.19` to pick up the centralized `CssContractTypeInfo` API in Foundation's `one-ui-css` module (Foundation PR [#819](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/819), already merged + published).

**Additional Note:**

CSS widgets that consume Foundation's `ContractViewState` (Contracts, CssMeter, AnonMeter, Consumption-CSS, Consumption-CSS-Simple, DynamicTariffs) can now migrate off their per-widget `when (type)` icon mapping and German label fallback blocks. Migration guide: `one-ui-css/MIGRATION.md` in Foundation. The Contracts widget POC migration follows in a separate PR.

**Deprecations (if any):**

None.

[OP-16151]: https://endios.atlassian.net/browse/OP-16151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ