### PR TITLE
OP-16151 Bump version.foundation to 5.4.20

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.19"
+version.foundation = "5.4.20"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.43"


### PR DESCRIPTION
## Summary

Companion to [endiosOneFoundation-Android#823](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/823) (merged) — bumps `version.foundation` from 5.4.19 → 5.4.20 so widget builds pick up the css_ic_* drawable resync and SUBSCRIPTION_RIGHT label fallback.

## Test plan

- [ ] Widget consumers using `version.foundation` resolve 5.4.20 from mavenLocal/SFTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)