### PR TITLE
OP-16290 Bump Foundation to 5.4.21 and Auth to 5.0.44

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.20"
+version.foundation = "5.4.21"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.43"
+version.foundation_auth = "5.0.44"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` 5.4.19 → 5.4.21 (removes hallucinated `registerUrl`)
- Bumps `version.foundation_auth` 5.0.43 → 5.0.44 (removes `registerUrl` usage — crash fix)

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/824
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/67

## Test plan
- None needed — version bump only