### PR TITLE
OP-16290 Bump Foundation + Auth versions (release hotfix)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.19-RC"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.19-RC"
-version.foundation_auth = "5.0.44"
+version.foundation_auth = "5.0.44-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,9 +50,9 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.19"
+version.foundation = "5.4.19-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.19"
+version.foundation_release = "5.4.19-RC"
 version.foundation_auth = "5.0.44"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.18"
+version.foundation = "5.4.19"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.43"
+version.foundation_release = "5.4.19"
+version.foundation_auth = "5.0.44"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_release` 5.3.29-RC → 5.4.19 (aligns STABLE with hotfix)
- Bumps `version.foundation` 5.4.18 → 5.4.19
- Bumps `version.foundation_auth` 5.0.43 → 5.0.44

This fixes the `NoSuchMethodError` crash on all CSS widgets in release v26.04.

## Companion PRs
- Foundation release: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/825
- Auth release: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/68
- Foundation develop: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/824
- Auth develop: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/67
- Android-Config develop: https://github.com/endiosGmbH/Android-Config/pull/684

## Test plan
- QA on CSS 2.0 test app (productionDebug) — open any widget requiring login to verify no crash