### PR TITLE
OP-15821 Bump foundation_auth to 5.0.45

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.21"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.44"
+version.foundation_auth = "5.0.45"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Pairs with endiosOneFoundation-Auth-Android [PR #70](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/70), which bumps `pomVersion` to `5.0.45` so the round-3 password-recovery fixes (analytics, input retention, tooltips, spinner) publish under a unique coordinate.
- The previous `5.0.44` coordinate was already taken by OP-16290's crash-fix binary, so develop's round-3 source on Auth currently maps to a stale Maven artifact.

## Why draft
Hold this PR until `5.0.45` is actually published to `mvn.endios.de` from the Auth repo. Merging earlier would break consumer builds (artifact not yet available).

## Test plan
- [ ] Wait for Auth PR #70 to merge.
- [ ] `./gradlew :platform-auth:publish` from Auth `develop`.
- [ ] Confirm `5.0.45` is visible in `mvn.endios.de/android`.
- [ ] Mark this PR ready for review and merge.
- [ ] Rebuild `endiosOneApp-Android/develop` and re-verify the round-3 fixes Tiep flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)