### PR TITLE
OP-15821 Bump foundation_auth to 5.0.46

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.22"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.45"
+version.foundation_auth = "5.0.46"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary

Retargets app builds onto the round-4 auth artifact published from
endiosGmbH/endiosOneFoundation-Auth-Android#71. After both PRs merge, a
fresh Widgetizer build off endiosOneApp `develop` will pull
`platform-auth:5.0.46`.

## Test plan

- [ ] Merge **after** the auth PR (#71) merges and the `5.0.46` artifact
      is on the maven repo. Same ordering as `0f2cb1f`/round-3.
- [ ] Trigger Widgetizer build → confirm Tiep retests on Herborn Test
      App. Expected: invalid input → red field + warning triangle, no
      caption text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)