### PR TITLE
OP-15916 Bump version.foundation 5.4.22 → 5.4.24

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.22"
+version.foundation = "5.4.24"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.46"


### PR DESCRIPTION
## Merge order

**3rd in line.** Merge after foundation #826 has published `5.4.24` to maven. This bump unblocks **auth #72's** CI — without it, `LoginViewModel` fails to compile against the old foundation jar (no `autologin` package).

## Summary

Bumps `version.foundation`: `5.4.22` → `5.4.24`.

Now points at the `ForwardedAutoLoginFieldsHelper` foundation. Skipping intermediate `5.4.23` because it was published locally during PR review and risks maven caching on CI.

## Companion PRs (merge in this order)

1. `endiosOneFoundation-Android#826` — foundation `ForwardedAutoLoginFields` + helper.
2. `endiosOneFoundation-Auth-Android#72` — auth-side multi-field plumbing + `AuthCompletionViewModel` refactor.
3. **THIS PR** — Android-Config `version.foundation` bump.
4. **(separate PR — opening shortly)** — Android-Config `version.foundation_auth` 5.0.46 → 5.0.47, lands after auth #72 publishes from develop CI.
5. `oneWidgetProfilePremium-Android#149` — widget consumes the helper.
6. `endiosOneApp-Android#2390` — version-bump pin (cssProfile dep).

## Why split

`version.foundation` and `version.foundation_auth` bumps depend on different upstream merges:

- `version.foundation` only needs foundation #826 (already merged + publishing).
- `version.foundation_auth` needs auth #72 to merge first and the develop-CI republish to land.

Splitting lets this one merge ASAP to unblock auth CI; the foundation_auth bump waits for auth #72.

## Test plan

- [ ] CI green on Android-Config.
- [ ] After merge: auth #72 CI compiles cleanly (resolves foundation `5.4.24`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)