### PR TITLE
OP-16377 Bump Foundation to 5.4.20-RC (release hotfix)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,9 +50,9 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.19-RC"
+version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.19-RC"
+version.foundation_release = "5.4.20-RC"
 version.foundation_auth = "5.0.44-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` and `version.foundation_release` to `5.4.20-RC`
- Companion PR for endiosOneFoundation-Android#828

## Companion PRs
- https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/828

## Test plan
- N/A — version bump only