### PR TITLE
OP-16377 Bump version.foundation to 5.4.23

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.22"
+version.foundation = "5.4.23"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.45"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` to `5.4.23`
- Companion PR for endiosOneFoundation-Android#829

## Companion PRs
- https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/829

## Test plan
- N/A — version bump only