### PR TITLE
OP-15821 Bump foundation_auth to 5.0.45-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.19-RC"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.19-RC"
-version.foundation_auth = "5.0.44-RC"
+version.foundation_auth = "5.0.45-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary

Pairs with [endiosOneFoundation-Auth-Android PR #73](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/73) (OP-15821 rounds 3 + 4 backport to `release/v26.04`).

`5.0.44-RC` is missing both:
- Round 3 (auth #66) — analytics dedup on skip→recovery, user-input retention on submit failure, BE-driven per-field tooltip rendering + TalkBack hint, VM-driven loading spinner.
- Round 4 (auth #71) — drops the hardcoded German validation-error fallback. When BE leaves `validationDescription` null, the field shows red border + warning icon with no caption text. Tiep's confirmed release-blocker fix for 26.04.

Pointing release builds to `5.0.45-RC` once auth PR #73 publishes.

## Order of operations

1. Auth PR #73 merges → release-branch CI publishes `5.0.45-RC`.
2. Mark this PR ready and merge.
3. Trigger Widgetizer Herborn Test App build from `release/v26.04`.

## Test plan

- [ ] Auth `5.0.45-RC` artifact is on Maven before merging this PR.
- [ ] After merge: Widgetizer Herborn Test App build picks up `5.0.45-RC`.
- [ ] Tiep retests password recovery on the release-branch build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)