### PR TITLE
OP-15916 Bump version.foundation_auth 5.0.46 → 5.0.47

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.22"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.46"
+version.foundation_auth = "5.0.47"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Merge order

**4th in line.** Merge **after** auth #72 has been merged + republished from develop CI (so maven actually has `5.0.47`). Once merged, this unblocks downstream widget #149 and app #2390 from resolving the new auth artifact without override pins.

## Summary

Bumps `version.foundation_auth`: `5.0.46` → `5.0.47`.

Now points at the auth-side multi-field plumbing + `AuthCompletionViewModel` SavedStateHandle refactor (OP-15916).

## Why this is split from #688

The two Android-Config bumps depend on different upstream merges:

- `version.foundation` (#688) only needs foundation #826 — already merged + publishing. Can land now to unblock auth #72's CI.
- `version.foundation_auth` (this PR) needs auth #72 to merge + the develop-CI republish. Must land later.

Splitting lets #688 merge ASAP without dragging this one along.

## Companion PRs (merge in this order)

1. `endiosOneFoundation-Android#826` — foundation `ForwardedAutoLoginFields` + helper. ✅ merged
2. `endiosGmbH/Android-Config#688` — `version.foundation` 5.4.22 → 5.4.24.
3. `endiosOneFoundation-Auth-Android#72` — auth-side multi-field plumbing + `AuthCompletionViewModel` refactor.
4. **THIS PR** — `version.foundation_auth` 5.0.46 → 5.0.47.
5. `oneWidgetProfilePremium-Android#149` — widget consumes the helper.
6. `endiosOneApp-Android#2390` — version-bump pin (cssProfile dep).

## Test plan

- [ ] CI green on Android-Config.
- [ ] After merge: widget #149 and app #2390 build resolve `5.0.47` without override pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)