### PR TITLE
OP-16492 Bump foundation LATEST to 5.4.26

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.25"
+version.foundation = "5.4.26"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) from 5.4.25 to 5.4.26

## Companion PRs
- https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/831