### PR TITLE
OP-15916 [Android-Config] Bump foundation → release/v26.04 (part 1)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,9 +50,9 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.19-RC"
+version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.19-RC"
+version.foundation_release = "5.4.20-RC"
 version.foundation_auth = "5.0.45-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary

Release cherry-pick of [#688](https://github.com/endiosGmbH/Android-Config/pull/688) (`69bebc9`) onto `release/v26.04`.

- `version.foundation` + `version.foundation_release`: `5.4.19-RC → 5.4.20-RC` (release-branch consumers read `_release` via the `isReleaseBranch()` selector — both are bumped to keep them in sync, matching prior release-branch convention).

Part 1 of the Android-Config release split. Picks up the release-line version of [`endiosOneFoundation-Android` #832](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/832).

Part 2 — the `version.foundation_auth` bump — is in [#696](https://github.com/endiosGmbH/Android-Config/pull/696) and must land after [`endiosOneFoundation-Auth-Android` #74](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/74) publishes.

[OP-15916 on Jira](https://endios.atlassian.net/browse/OP-15916)

## Merge order — OP-15916 release chain

1. [`endiosOneFoundation-Android` #832](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/832) — foundation helper
2. **→ THIS PR** — `Android-Config` — `version.foundation` bump (unblocks auth CI)
3. [`endiosOneFoundation-Auth-Android` #74](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/74) — auth-side plumbing
4. [`Android-Config` #696](https://github.com/endiosGmbH/Android-Config/pull/696) — `version.foundation_auth` bump (unblocks widget+app CI)
5. [`oneWidgetProfilePremium-Android` #153](https://github.com/endiosGmbH/oneWidgetProfilePremium-Android/pull/153) — widget consumes the helper
6. [`endiosOneApp-Android` #2408](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2408) — app bumps cssProfile dep

⚠️ Merge ONLY after [`endiosOneFoundation-Android` #832](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/832) has merged AND its release-CI artifact republish has completed — otherwise auth's CI can't resolve `foundation 5.4.20-RC`.

## Test plan

- [ ] Verify `foundation 5.4.20-RC` jar is published to maven before merging.
- [ ] Auth #74 CI goes green after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)