### PR TITLE
OP-15916 [Android-Config] Bump foundation_auth → release/v26.04 (part 2)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.19-RC"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.19-RC"
-version.foundation_auth = "5.0.45-RC"
+version.foundation_auth = "5.0.46-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary

Release cherry-pick of [#692](https://github.com/endiosGmbH/Android-Config/pull/692) (`e99cbe4`) onto `release/v26.04`.

- `version.foundation_auth`: `5.0.45-RC → 5.0.46-RC`.

Part 2 of the Android-Config release split. Picks up the release-line version of [`endiosOneFoundation-Auth-Android` #74](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/74).

The branch is now based directly on `release/v26.04` (rebased — the `version.foundation` bump lives in #695). Diff is a single line.

[OP-15916 on Jira](https://endios.atlassian.net/browse/OP-15916)

## Merge order — OP-15916 release chain

1. [`endiosOneFoundation-Android` #832](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/832) — foundation helper
2. [`Android-Config` #695](https://github.com/endiosGmbH/Android-Config/pull/695) — `version.foundation` bump (unblocks auth CI)
3. [`endiosOneFoundation-Auth-Android` #74](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/74) — auth-side plumbing
4. **→ THIS PR** — `Android-Config` — `version.foundation_auth` bump (unblocks widget+app CI)
5. [`oneWidgetProfilePremium-Android` #153](https://github.com/endiosGmbH/oneWidgetProfilePremium-Android/pull/153) — widget consumes the helper
6. [`endiosOneApp-Android` #2408](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2408) — app bumps cssProfile dep

⚠️ Merge ONLY after [`endiosOneFoundation-Auth-Android` #74](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/74) has merged AND its release-CI artifact republish has completed — otherwise widget/app consumers resolve an un-published `foundation_auth 5.0.46-RC`.

## Test plan

- [ ] Verify `foundation_auth 5.0.46-RC` jar is published to maven before merging.
- [ ] Widget #153 and app #2408 CI go green after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)