### PR TITLE
OP-15950 [Android][Config] Bump version.foundation to 5.4.29

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.28"
+version.foundation = "5.4.29"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
## Summary

Bumps `version.foundation` (LATEST) to `5.4.29` to pick up the OP-15950 sequential-overlay fix.

Companion PR: endiosGmbH/endiosOneFoundation-Android#833 ([OP-15950](https://endios.atlassian.net/browse/OP-15950))

Originally bumped to `5.4.26` → re-bumped to `5.4.28` → re-bumped to `5.4.29` as develop's `pomVersion` advanced (OP-16492 took 5.4.26, OP-16545 took 5.4.28).

## Test plan

- [ ] Wait for Foundation #833 to merge to `develop` and publish 5.4.29 to maven
- [ ] Merge this once 5.4.29 is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-15950]: https://endios.atlassian.net/browse/OP-15950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ