### PR TITLE
OP-16492 Bump foundation release to 5.4.21-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.20-RC"
+version.foundation_release = "5.4.21-RC"
 version.foundation_auth = "5.0.45-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` and `version.foundation_release` from 5.4.20-RC to 5.4.21-RC on release/v26.04

## Companion PRs
- Foundation release: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/834
- Foundation develop: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/831