### PR TITLE
OP-16532 Bump Foundation LATEST to 5.4.27

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.26"
+version.foundation = "5.4.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` (LATEST) from 5.4.26 to 5.4.27

## Companion PRs
- endiosOneFoundation-Android#835 — Fix analytics opt-out overwritten by global config flag

## Test plan
- CI build passes with updated version