### PR TITLE
OP-16532 Bump Foundation STABLE to 5.4.22-RC

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.21-RC"
+version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.46-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Bump `version.foundation_release` (STABLE) from 5.4.21-RC to 5.4.22-RC

## Companion PRs
- endiosOneFoundation-Android#836 — Fix analytics opt-out (release/v26.04)
- endiosOneFoundation-Android#835 — Same fix targeting develop
- Android-Config#699 — Bump Foundation LATEST to 5.4.27

## Test plan
- CI build passes with updated version