### PR TITLE
OP-16565 [Android][Config] Bump foundation LATEST to 5.4.30

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.27"
+version.foundation = "5.4.28"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.28"
+version.foundation = "5.4.30"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.30"
+version.foundation = "5.4.31"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
**Ticket:** [OP-16565](https://endios.atlassian.net/browse/OP-16565 "Link to JIRA")

**Purpose of this Pull Request:**

Bumps `version.foundation` (LATEST) to `5.4.30` to pick up the Copilot-review revision of [endiosGmbH/endiosOneFoundation-Android#837](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/837): the app-rating prompt is now gated on a new `MainViewModel.serverConfigLoaded` StateFlow (true once `appConfigContainer` holds a server-sourced config — cache hit OR fresh fetch) rather than on `State.LoadConfigSuccess` alone. The previous state-only gate did not close the OP-16565 race on the production `hotStartNoRegister = true` path; the new gate suppresses the prompt on fresh installs with an empty cache until a real server config arrives.

Re-bumped from `5.4.28` → `5.4.30` because develop took 5.4.28 via #839 (OP-16545), and #838 (OP-16537) claimed 5.4.29.

**Additional Note:**

`version.foundation_release` (STABLE) is **not** bumped.

**Deprecations (if any):** None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-16565]: https://endios.atlassian.net/browse/OP-16565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ