### PR TITLE
OP-16537 [Android][Config] Bump version.foundation to 5.4.29

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.27"
+version.foundation = "5.4.28"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.29"
+version.foundation = "5.4.30"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.28"
+version.foundation = "5.4.29"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
## Summary

Bumps `version.foundation` (LATEST) to `5.4.29`. Companion of endiosGmbH/endiosOneFoundation-Android#838 (push permission re-check on resume + Copilot review fixes).

Re-bumped from `5.4.28` → `5.4.29` because develop's `pomVersion` advanced to 5.4.28 via #839 (OP-16545), so Foundation #838 was rebased to 5.4.29.

## Test plan

- [x] Wait for Foundation #838 to merge to `develop` and publish 5.4.29 to mavenLocal / SFTP repo
- [ ] Confirm downstream LATEST consumers resolve 5.4.29
- [ ] Merge this once 5.4.29 is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)