### PR TITLE
OP-15821 Bump foundation_test_library to 5.0.10

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.foundation = "5.4.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"
-version.foundation_test_library = "5.0.9"
+version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google
 version.google_exoplayer = "2.17.1"


### PR DESCRIPTION
## Summary

- Bump `version.foundation_test_library` from `5.0.9` to `5.0.10`

## Companion PRs
- endiosGmbH/endiosOneFoundation-Test-Android#14

## Test plan
- [ ] Widget test apps compile against updated test library

Generated with [Claude Code](https://claude.com/claude-code)