### PR TITLE
OP-16545 [Android][Config] Bump version.foundation to 5.4.28

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.27"
+version.foundation = "5.4.28"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
## Summary

Companion bump for [endiosOneFoundation-Android#839](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/839) (merged).

Bumps `version.foundation` from `5.4.27` → `5.4.28` so apps pick up the OP-16545 `CanvasBarChart` fixes (`forceShowAllLabels` parameter + working `focusedTimestamp` scroll).

Ticket: [OP-16545](https://endios.atlassian.net/browse/OP-16545)

## Note

Three other open PRs (#702, #701, #697) carry the identical 5.4.27 → 5.4.28 diff for separate tickets. Whichever lands first makes the rest trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-16545]: https://endios.atlassian.net/browse/OP-16545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ