### PR TITLE
OP-16299 [Android][Config] Bump version.foundation to 5.4.32

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.27"
+version.foundation = "5.4.29"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.29"
+version.foundation = "5.4.30"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
Companion to [endiosOneFoundation-Android#840](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/840) for [OP-16299](https://endios.atlassian.net/browse/OP-16299).

Bumps `version.foundation` (LATEST) to `5.4.32` so consumers — including Auth's CI build — can resolve the new `SessionExpiredInterceptor` + `SessionEventBus` from the remote maven.

`version.foundation_release` (STABLE) is intentionally untouched.

> **Note** — re-bumped twice from the original 5.4.30:
> - develop landed Android-Config #702 (OP-16537) claiming `foundation:5.4.30`
> - develop landed Android-Config #701 (OP-16565) claiming `foundation:5.4.31`
>
> Foundation #840 now publishes `5.4.32`, so this PR follows suit.

### ⚠️ Merge order

This PR must merge **after** Foundation #840 has merged to develop and develop CI has published `foundation:5.4.32` to the remote maven. Merging this earlier leaves Android-Config pointing at an artifact that doesn't yet exist.

The Auth-side companion bump for `version.foundation_auth` lives in a **separate** PR ([linked below](https://github.com/endiosGmbH/Android-Config/pulls?q=is%3Apr+OP-16299)) and must merge **after** the Auth PR ships its artifact — splitting it out avoids a window where Android-Config says "use platform-auth 5.0.48" but the artifact hasn't been published yet.

### Full sequence
1. [endiosOneFoundation-Android#840](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/840) → develop CI publishes `foundation:5.4.32`
2. **This PR** → Auth CI can now resolve Foundation 5.4.32
3. [endiosOneFoundation-Auth-Android#75](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/75) → develop CI publishes `platform-auth:5.0.48`
4. Sibling Android-Config PR (foundation_auth → 5.0.48) → consumers resolve the new Auth

[OP-16299]: https://endios.atlassian.net/browse/OP-16299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
