### PR TITLE
OP-16299 [Android][Config] Bump version.foundation_auth to 5.0.48

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.47"
+version.foundation_auth = "5.0.48"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
Companion to [endiosOneFoundation-Auth-Android#75](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/75) for [OP-16299](https://endios.atlassian.net/browse/OP-16299).

Bumps \`version.foundation_auth\` to \`5.0.48\` so consumers (notably endiosOneApp-Android) pick up the new \`SessionRedirector\` + \`SessionEvent.LoginSucceeded\` emission.

### ⚠️ Merge order

This PR must merge **after** Auth #75 has merged to develop and develop CI has published \`platform-auth:5.0.48\` to the remote maven. Merging this earlier leaves Android-Config pointing at an artifact that doesn't yet exist → every downstream build fails until Auth catches up.

The sibling [Android-Config #705](https://github.com/endiosGmbH/Android-Config/pull/705) (\`version.foundation\` → 5.4.29) must land first — it is what allows Auth's own CI to build against the new Foundation, which is the precondition for Auth #75 being mergeable.

### Full sequence
1. [endiosOneFoundation-Android#840](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/840) → develop CI publishes \`foundation:5.4.29\`
2. [Android-Config #705](https://github.com/endiosGmbH/Android-Config/pull/705) → Auth CI can now resolve Foundation 5.4.29
3. [endiosOneFoundation-Auth-Android#75](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/75) → develop CI publishes \`platform-auth:5.0.48\`
4. **This PR** → consumers (endiosOneApp etc.) resolve the new Auth

[OP-16299]: https://endios.atlassian.net/browse/OP-16299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ