### PR TITLE
OP-16357 Bump Foundation LATEST to 5.4.30

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.29"
+version.foundation = "5.4.30"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.47"


### PR DESCRIPTION
Companion to https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/841

Bumps `version.foundation` (LATEST) from 5.4.29 to 5.4.30 for the persistent TabBar POC.