### PR TITLE
OP-16663 Bump foundation_auth to 5.0.48

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.31"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.47"
+version.foundation_auth = "5.0.48"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
Companion to https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/76

Bumps `version.foundation_auth` from 5.0.47 to 5.0.48.