### PR TITLE
OP-16359 Bump foundation_auth to 5.0.51

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.31"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.48"
+version.foundation_auth = "5.0.49"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.33"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.50"
+version.foundation_auth = "5.0.51"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.33"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.49"
+version.foundation_auth = "5.0.50"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `version.foundation_auth` from 5.0.49 to 5.0.51

## Companion PRs
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/78

🤖 Generated with [Claude Code](https://claude.com/claude-code)