### PR TITLE
Merge release to master

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.34"
+version.foundation_auth = "5.0.35"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.8"
+version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.38"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.10"
+version.foundation = "5.4.11"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.7"
+version.foundation = "5.4.8"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.37"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.19-RC"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.19-RC"
-version.foundation_auth = "5.0.44"
+version.foundation_auth = "5.0.44-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.15"
+version.foundation = "5.4.16"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.42"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.14"
+version.foundation = "5.4.15"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.42"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.11"
+version.foundation = "5.4.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.13"
+version.foundation = "5.4.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.41"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.26"
+version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.33"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.17"
+version.foundation = "5.4.18"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.43"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.16"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.42"
+version.foundation_auth = "5.0.43"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.foundation = "5.4.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.40"
-version.foundation_test_library = "5.0.8"
+version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google
 version.google_exoplayer = "2.17.1"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.4"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.35"
+version.foundation_auth = "5.0.36"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.41"
+version.foundation_auth = "5.0.42"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.8"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.37"
+version.foundation_auth = "5.0.36"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.0"
+version.foundation = "5.4.2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.25"
+version.foundation = "5.3.26"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.32"
+version.foundation_auth = "5.0.33"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.0"
+version.foundation = "5.4.1"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.12"
+version.foundation = "5.4.13"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.40"
+version.foundation_auth = "5.0.41"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.33"
+version.foundation_auth = "5.0.34"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.37"
+version.foundation_auth = "5.0.38"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.3"
+version.foundation = "5.4.5"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.35"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.36"
+version.foundation_auth = "5.0.37"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.38"
+version.foundation_auth = "5.0.39"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.9"
+version.foundation = "5.4.10"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.5"
+version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.36"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.40"
+version.foundation_auth = "5.0.41"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.27"
+version.foundation = "5.3.28"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"

--- a/version.gradle
+++ b/version.gradle
@@ -50,9 +50,9 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.19"
+version.foundation = "5.4.19-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.19"
+version.foundation_release = "5.4.19-RC"
 version.foundation_auth = "5.0.44"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.3"
+version.foundation = "5.4.4"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.35"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.10"
+version.foundation = "5.4.11"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.40"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.3.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.34"
+version.foundation_auth = "5.0.35"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.18"
+version.foundation = "5.4.19"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.29-RC"
-version.foundation_auth = "5.0.43"
+version.foundation_release = "5.4.19"
+version.foundation_auth = "5.0.44"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.16"
+version.foundation = "5.4.17"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.29-RC"
 version.foundation_auth = "5.0.43"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.39"
+version.foundation_auth = "5.0.40"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.3.25"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.3.7-RC"
+version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.32"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -50,10 +50,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.5"
+version.foundation = "5.4.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
-version.foundation_auth = "5.0.36"
+version.foundation_auth = "5.0.37"
 version.foundation_test_library = "5.0.8"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.3.27"
+version.foundation = "5.4.0"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.3.25"
 version.foundation_auth = "5.0.34"

--- a/version.gradle
+++ b/version.gradle
@@ -50,9 +50,9 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.19-RC"
+version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.19-RC"
+version.foundation_release = "5.4.20-RC"
 version.foundation_auth = "5.0.45-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.20-RC"
+version.foundation_release = "5.4.21-RC"
 version.foundation_auth = "5.0.45-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -52,7 +52,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.21-RC"
+version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.46-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.19-RC"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.19-RC"
-version.foundation_auth = "5.0.44-RC"
+version.foundation_auth = "5.0.45-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.21-RC"
-version.foundation_auth = "5.0.45-RC"
+version.foundation_auth = "5.0.46-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.20-RC"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.46-RC"
+version.foundation_auth = "5.0.47-RC"
 version.foundation_test_library = "5.0.9"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Release v26.04

### Changes (72 commits)
- e0b1ca9 Merge remote-tracking branch 'origin/master' into release/v26.04
- aa295e0 Merge pull request #709 from endiosGmbH/hotfix/OP-16663-bump-auth-version
- 781674a OP-16663 Bump foundation_auth to 5.0.47-RC
- 5848983 Merge pull request #700 from endiosGmbH/fix/OP-16532-bump-foundation-release
- 2dcaa8c OP-16532 Bump Foundation STABLE to 5.4.22-RC
- 43e02d4 OP-15916 Bump version.foundation_auth 5.0.45-RC → 5.0.46-RC (release cherry-pick of #692) (#696)
- ed8158b Merge pull request #698 from endiosGmbH/fix/OP-16492-bump-foundation-release
- 0437a17 OP-16492 Bump foundation release to 5.4.21-RC
- 13d1151 OP-15916 Bump version.foundation 5.4.19-RC → 5.4.20-RC (release cherry-pick of #688) (#695)
- 9ccd3aa OP-15821 Bump foundation_auth to 5.0.45-RC (#691)
- eaf90d9 Merge pull request #685 from endiosGmbH/hotfix/OP-16290-bump-versions
- 7de46f3 OP-16290 Add -RC postfix to Auth release version
- e84cf35 OP-16290 Add -RC postfix to Foundation release version
- bbb9aaf OP-16290 Bump Foundation to 5.4.19 and Auth to 5.0.44 (release hotfix)
- 51bf61b OP-16058 Bump version.foundation to 5.4.18 (#677)
- 04571f2 OP-16034 Bump version.foundation to 5.4.17 (#676)
- 614947c OP-15821 Bump foundation_auth to 5.0.43 (#675)
- f86be02 OP-16092 Bump Foundation version to 5.4.16 (#673)
- 79af382 Merge pull request #670 from endiosGmbH/feature/OP-16196-bump-foundation-version
- b67caff OP-16196 Bump Foundation version to 5.4.15
- 8eba82c Merge pull request #665 from endiosGmbH/feature/OP-15787-bump-auth-version-qa-round4
- 18ba97a OP-15787 Bump foundation_auth to 5.0.42
- 8ca162f Merge pull request #664 from endiosGmbH/feature/OP-15787-bump-versions-qa-round3
- eee039e OP-15821 Bump foundation_auth 5.0.40 → 5.0.41 (#660)
- 9280b1f OP-15787 Bump version.foundation to 5.4.14
- 2fe879c OP-15787 Bump version.foundation to 5.4.13 and foundation_auth to 5.0.41
- 3c7187f Merge pull request #663 from endiosGmbH/feature/OP-14769-bump-test-library-version
- c8dfa52 OP-14769 Bump foundation_test_library to 5.0.9
- 4356cfa Merge pull request #662 from endiosGmbH/fix/bump-foundation-5.4.12
- 79b9027 Bump version.foundation to 5.4.12