### PR TITLE
AGENCY-7529: Bump version.foundation to 5.5.0

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.33"
+version.foundation = "5.5.0"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.48"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) from `5.4.33` to `5.5.0`.
- Pairs with [endiosOneFoundation-Android #846](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/846), which lifts `rememberSafeNavigateBack` and the horizontal slide extensions out of `oneWidgetContent-Android` / `oneWidgetOfferWorld-Android` into Foundation.
- MINOR bump per `foundationAPI.md` §Breaking Change Policy: removes two public object members (`OneNavigationTransitions.slideHorizontally` / `popSlideHorizontally`, zero callers) and adds new public functionality.

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/846

## Test plan
- [ ] Merge order: Foundation #846 publishes `5.5.0` first, then this PR merges (LATEST consumers pick it up via `develop`).
- [ ] `version.foundation_release` is **unchanged** (`5.4.22-RC`) — release branches keep using STABLE.