### PR TITLE
OP-16299 [Android][Config] Bump version.foundation_auth to 5.0.49

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.33"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.48"
+version.foundation_auth = "5.0.49"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
Companion to [endiosOneFoundation-Auth-Android#82](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/82) for [OP-16299](https://endios.atlassian.net/browse/OP-16299).

Bumps `version.foundation_auth` to `5.0.49` so consumers (notably endiosOneApp-Android) force-re-resolve the Auth jar after Auth #82's republish-safety bump.

### Why this PR exists (not the original OP-16299 5.0.48 bump)

The original Config bump for OP-16299 was [#706](https://github.com/endiosGmbH/Android-Config/pull/706), but that PR was superseded by [#708](https://github.com/endiosGmbH/Android-Config/pull/708) (OP-16663), which independently bumped `version.foundation_auth` to 5.0.48 first. By the time OP-16299's Auth side (Auth #75) merged, develop already had `5.0.48` from #708 — and on the Auth side, Auth #75 merged onto a develop that already had pomVersion 5.0.48 from Auth #76, so develop CI **republished** the same `platform-auth:5.0.48` artifact with the combined OP-16663 + OP-16299 contents.

Gradle caches release versions by string and won't re-fetch when the version is unchanged. So any consumer that resolved `5.0.48` between 2026-05-22 and 2026-05-26 still has the earlier objectHash-only jar in `~/.gradle/caches/modules-2`, silently missing `SessionRedirector` / `LoginSucceeded` from OP-16299.

This PR (paired with Auth #82) gives consumers a new version string and forces a clean re-resolve.

### ⚠️ Merge order

This PR must merge **after** Auth #82 has merged to develop and develop CI has published `platform-auth:5.0.49` to the remote maven. Merging earlier leaves Android-Config pointing at an artifact that doesn't yet exist.

### Sequence

1. [endiosOneFoundation-Auth-Android#82](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/82) → develop CI publishes `platform-auth:5.0.49` (combined OP-16663 + OP-16299 from current develop tip)
2. **This PR** → consumers (endiosOneApp etc.) resolve the new Auth artifact

### Closes

- Closes #706 (the original OP-16299 5.0.48 bump, now redundant)

[OP-16299]: https://endios.atlassian.net/browse/OP-16299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ