### PR TITLE
OP-16299 [Android][Config] Bump version.foundation_auth to 5.0.50

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.4.33"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.49"
+version.foundation_auth = "5.0.50"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
Companion to [endiosOneFoundation-Auth-Android#83](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/83) for [OP-16299](https://endios.atlassian.net/browse/OP-16299).

Bumps `version.foundation_auth` to `5.0.50` so consumers pick up the follow-up fix in Auth #83: a mid-widget 401 now redirects to the app's **configured login flow** (`AuthActivity` / external webview login) instead of cold-restarting to the auth-less launcher dashboard. The previous behavior left users on the dashboard with no login prompt on public-dashboard apps like CSSvTwo.

### ⚠️ Merge order

Merge **after** Auth #83 has merged to develop and develop CI has published `platform-auth:5.0.50` to the remote maven. Merging earlier points Android-Config at an artifact that doesn't yet exist.

### Sequence
1. [endiosOneFoundation-Auth-Android#83](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/83) → develop CI publishes `platform-auth:5.0.50`
2. **This PR** → consumers (endiosOneApp etc.) resolve the fixed Auth

[OP-16299]: https://endios.atlassian.net/browse/OP-16299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ