### PR TITLE
OP-16722 Bump version.foundation to 5.5.3

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.2"
+version.foundation = "5.5.3"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.51"


### PR DESCRIPTION
## What this is

Companion pin bump for **endiosOneFoundation-Android#848** — the `WidgetLayoutManagerNew` dedup that resolves the OW v2.0 Gallery tile rendering blank (OP-16629).

Bumps `version.foundation` to **`5.5.3`** in `version.gradle`, so consumer repos (endiosOneApp, every widget, Foundation-Test) start resolving the new artifact.

> Re-targeted from `5.4.34` → `5.5.3` after Foundation `5.5.1` (OP-16360) and `5.5.2` (OP-16493) shipped on develop while this stack was in review. `develop` was merged in (commit `535e1bd`) to resolve the `version.gradle` collision; no rebase.

## Merge order

⚠️ **Do not merge until Foundation 5.5.3 is published to maven.** Foundation publish is `workflow_dispatch` only (not auto on develop merge) — the user triggers it manually. If `version.foundation` ticks ahead of what's actually on `mvn.endios.de`, every downstream build breaks in the gap.

Sequence:
1. Foundation #848 merged to develop.
2. User manually triggers the Maven-upload workflow; `5.5.3` published.
3. Mark this PR ready → merge.

⚠️ **Also do not merge before Android-Config #722** (which bumps `version.foundation` to `5.5.2` for OP-16493) — otherwise merging #722 afterwards would downgrade `version.foundation` from `5.5.3` back to `5.5.2`. Order should be: #722 merges first, then this PR.

Foundation-Test #16 (the companion `WidgetLayoutManagerDuplicateViewTest`) becomes meaningfully green once step 2 + this PR land, because Foundation-Test pulls its Foundation version from `version.gradle`.

## Out of scope (intentional)

This PR bumps **only** `version.foundation`. `version.foundation_auth` / `version.foundation_test_library` / etc. stay untouched — each artifact bump is its own PR, gated on its own publish.

## Related

- endiosOneFoundation-Android#848 — the actual `WidgetLayoutManagerNew` fix (now `5.5.3`).
- endiosOneFoundation-Test-Android#16 — instrumented invariant lock-in.
- Android-Config#722 — sibling Foundation bump (`5.5.1 → 5.5.2`) for OP-16493; merges before this PR.
- Android-Config#721 — sibling bump for `version.foundation_test_library` (`5.0.10 → 5.0.11`), independent track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)