### PR TITLE
OP-16722 Bump version.foundation_test_library to 5.0.11

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.foundation = "5.4.33"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.49"
-version.foundation_test_library = "5.0.10"
+version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"
 // google
 version.google_exoplayer = "2.17.1"


### PR DESCRIPTION
## What this is

Companion pin bump for **endiosOneFoundation-Test-Android#16** — the `WidgetLayoutManagerDuplicateViewTest` instrumented invariant lock-in that ships alongside the OP-16722 dedup in `WidgetLayoutManagerNew`.

Bumps `version.foundation_test_library` 5.0.10 → 5.0.11 in `version.gradle`, so consumer repos start resolving the new `testlibrary` / `test-app` artifacts.

## Merge order

⚠️ **Do not merge until Foundation-Test 5.0.11 is published to maven.** Per the [one-PR-per-artifact-bump rule](https://github.com/endiosGmbH/.../docs), if the pin ticks ahead of what's actually on `mvn.endios.de`, every downstream build resolving `dependency.foundation.test_library` (and `test_app`) breaks in the gap. The PR is intentionally left in **draft** until #16 is merged and its artifact uploaded.

Sequence:
1. endiosOneFoundation-Test-Android#16 merged to develop.
2. Maven upload runs and testlibrary 5.0.11 is published.
3. Mark this PR ready → merge.

## Out of scope (intentional)

This PR bumps **only** `version.foundation_test_library`. `version.foundation` (5.4.34) is the sibling PR #720 — each artifact bump merges only after its own publish.

## Related

- endiosOneFoundation-Test-Android#16 — the `WidgetLayoutManagerDuplicateViewTest` lock-in (draft).
- endiosOneFoundation-Android#848 — the actual `WidgetLayoutManagerNew` fix (draft).
- Android-Config#720 — sibling bump for `version.foundation` 5.4.34 (draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)