### PR TITLE
OP-16493 Bump version.foundation to 5.5.2

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.34"
+version.foundation = "5.5.1"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.49"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.1"
+version.foundation = "5.5.2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.51"

--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.4.33"
+version.foundation = "5.4.34"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.49"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` from `5.4.33` to **`5.5.2`**.
- Foundation 5.5.2 adds:
  - Optional `subline` + typography (`titleTextStyle`, `sublineTextStyle`) + colour (`titleColor`, `sublineColor`) params to `ContactBox` — all default-preserving so existing callers stay visually identical.
  - New `TYPE_X = "X"` social-media type constant; `TYPE_TWITTER = "TWITTER"` kept as a `@Deprecated` alias so the four downstream widgets that still reference it (`endiosOneSampleWidget-Android`, `endiosOneApp-Android` androidTest, `endiosOneFoundation-Check-Android`, `oneWidgetPublicTransport-Android` androidTest) continue to compile.
  - New `sealed class SocialMediaType(val typeValue: String, @StringRes val labelRes: Int)` with `data object Facebook` / `X` / `YouTube` / `Instagram` subclasses, plus four `translatable="false"` brand-name string resources. Future widgets that surface social-media rows reuse this instead of redefining their own type → label map.

> Re-targeted from `5.5.1` to `5.5.2` after OP-16360 shipped `5.5.1` from develop while this PR was in review. `develop` was merged in to resolve the version collision; new commit added on top to flip the value to `5.5.2` — no rebase.

## Companion PRs
- endiosOneFoundation-Android#849 — the Foundation 5.5.2 release.
- oneWidgetOffers-Android#324 — consumes the new `subline` field + `SocialMediaType` sealed class in the OW v2.0 Detail View.

## Merge order
1. endiosOneFoundation-Android#849 merges first. Wait for develop CI to publish Foundation `5.5.2` to maven.
2. **This PR (#722) merges next** — only after the artifact is available, per the memory rule that Android-Config bumps must follow the publish.
3. Then oneWidgetOffers-Android#324 merges into the OW v2.0 epic branch.

## Test plan
- [ ] Merge only after Foundation 5.5.2 is published to maven by develop CI.
- [ ] All consumer widgets resolve 5.5.2 cleanly on their next CI build.

> Note: this branch is named `feature/OP-16493-bump-foundation-5-4-35` from an earlier version pick that was re-targeted multiple times (`5.4.35` → `5.4.34` → `5.5.1` → `5.5.2`). Branch name is stale but harmless; the file content is the authoritative version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)