### PR TITLE
OP-16488 [Android][Config] Bump version.foundation to 5.5.4

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.3"
+version.foundation = "5.5.4"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.51"


### PR DESCRIPTION
**Ticket:** [OP-16488](https://endios.atlassian.net/browse/OP-16488 "Link to JIRA")

**Purpose of this Pull Request:**

Bumps `version.foundation` (LATEST) 5.5.3 → 5.5.4 to pull in the disabled One button label dimming fix.

Companion to Foundation PR endiosGmbH/endiosOneFoundation-Android#850. Merge only after Foundation 5.5.4 has been published.

`version.foundation_release` (STABLE) is unchanged.

**Additional Note:**

None.

**Deprecations (if any):**

None.

[OP-16488]: https://endios.atlassian.net/browse/OP-16488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ