### PR TITLE
OP-15498 Bump version.foundation_auth to 5.0.52

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.5.3"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.51"
+version.foundation_auth = "5.0.52"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
**Ticket:** [OP-15498](https://endios.atlassian.net/browse/OP-15498 "Link to JIRA")

**Purpose of this Pull Request:**

Bumps `version.foundation_auth` from `5.0.51` → `5.0.52` to pick up the autofill broadening fix.

**Companion PR:** https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/85

**Additional Note:**

LATEST version only (`version.foundation_auth`). Not bumping `foundation_release`.

[OP-15498]: https://endios.atlassian.net/browse/OP-15498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ