### PR TITLE
AGENCY-7577: Bump foundation (LATEST) to 5.5.7

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.5"
+version.foundation = "5.5.7"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.53"


### PR DESCRIPTION
**Ticket:** [AGENCY-7577](https://endios.atlassian.net/browse/AGENCY-7577 "Link to JIRA")

**Purpose of this Pull Request:**

Bumps `version.foundation` (LATEST) to 5.5.7 to pick up the dedicated X glyph for social media contacts in the detail view.

Main PR: endiosOneFoundation-Android#851

5.5.7 (not 5.5.4 / 5.5.5 / 5.5.6) because develop already published 5.5.4 (OP-16488), 5.5.5 (OP-16360), and 5.5.6 (OP-16478); the Foundation branch is rebased on top of all three.

**Additional Note:**

Only `version.foundation` (LATEST) is changed; `version.foundation_release` (STABLE) is untouched.

**Deprecations (if any):**

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGENCY-7577]: https://endios.atlassian.net/browse/AGENCY-7577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ