### PR TITLE
OP-16772 [Android][Config] Bump version.foundation to 5.5.9

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.8"
+version.foundation = "5.5.9"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.53"


### PR DESCRIPTION
**Ticket:** [OP-16772](https://endios.atlassian.net/browse/OP-16772 "Link to JIRA")

**Purpose of this Pull Request:**

Bump `version.foundation` (LATEST) → `5.5.9` to pick up the deletion of the deprecated `compose.oneButton` package (OP-16772). `version.foundation_release` (STABLE) is untouched.

> **Note on the version number:** the deletion was originally planned to publish as `5.5.6`, but `develop` advanced faster than expected and the deletion (Foundation #852) actually landed in **`5.5.9`** (commit `3bf42a2d`). Versions `5.5.6`–`5.5.8` are unrelated PRs that still contain `compose.oneButton`, so `5.5.9` is the first published version that drops it. Re-targeted from the original `5.5.7` and rebuilt as a single clean `5.5.8 → 5.5.9` commit on top of `develop`.

### Merge order — OP-16772 chain

| # | Step | PR | Status |
|---|------|----|--------|
| 1 | oneWidgetLottery — migrate cancel sheet off `compose.oneButton` | endiosGmbH/oneWidgetLottery-Android#97 | ✅ merged & republished |
| 2 | oneWidgetProfilePremium — migrate `CssProfileOverviewScreen` | endiosGmbH/oneWidgetProfilePremium-Android#164 | ✅ merged & republished |
| 3 | endiosOneApp — bump Lottery + CssProfile widget versions | endiosGmbH/endiosOneApp-Android#2471 | ✅ merged |
| 4 | Org-wide `compose.oneButton` re-grep — must show **no live reference** | — | ✅ verified 2026-06-02 (GitHub org search + local grep): no live consumer refs; only the package itself, commented `CaptionStylePicker` lines, the canonical `compose.buttons` helper, and docs |
| 5 | Foundation — delete `compose.oneButton` | endiosGmbH/endiosOneFoundation-Android#852 | ✅ merged & **published `5.5.9`** |
| 6 | **Android-Config — `version.foundation` → `5.5.9`** | **this PR** | ⏳ ready — `5.5.9` is published |

👉 **This PR is step 6.** Foundation `5.5.9` is already on Maven (step 5 done), so this is unblocked. Repos pull the version catalog at build time, which is why the bump only lands after the artifact is published.

**Deprecations (if any):**

None.


[OP-16772]: https://endios.atlassian.net/browse/OP-16772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
