### PR TITLE
OP-16360 [Android][Config] Bump version.foundation to 5.5.5

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.4"
+version.foundation = "5.5.5"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.52"


### PR DESCRIPTION
**Ticket:** [OP-16360](https://endios.atlassian.net/browse/OP-16360)

**Purpose of this Pull Request:**

Bumps `version.foundation` (LATEST) to 5.5.5 to pull in the MagicLinkCallbackParser rewrite that matches the Joules `convertToParams` wire contract.

Companion to Foundation PR endiosGmbH/endiosOneFoundation-Android#854. Merge only after Foundation 5.5.5 has been published.

**Note on stacking with #723:**

endiosGmbH/Android-Config#723 is also open and bumps `version.foundation` 5.5.3 → 5.5.4 (companion to Foundation PR #850, OP-16488 — disabled One button label fix). Whichever of #723 / this PR merges first, the other will need a trivial rebase. Once #723 is in, this PR's diff becomes 5.5.4 → 5.5.5.

`version.foundation_release` (STABLE) is unchanged.

**Additional Note:**

None.

**Deprecations (if any):**

None.

[OP-16360]: https://endios.atlassian.net/browse/OP-16360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ