### PR TITLE
OP-16478 [Android][Config] Bump version.foundation to 5.5.6

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -50,7 +50,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.5"
+version.foundation = "5.5.6"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.53"


### PR DESCRIPTION
**Purpose of this Pull Request:**
OP-16478 — Bump `version.foundation` (LATEST) `5.5.3` → `5.5.5` so downstream builds pick up the new notification-tracking primitives (`EventType.NOTIFICATION`, `OneAnalyticsService.trackNotificationEvent`, `NotificationConstants`). `version.foundation_release` (STABLE) is untouched.

**Merge order (all PRs are draft):**
1. endiosOneFoundation-Android Foundation 5.5.5 — https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/855 — **merge first, wait for publish.**
2. **This PR** — merge only after Foundation 5.5.5 has published.
3. endiosOneApp-Android — https://github.com/endiosGmbH/endiosOneApp-Android/pull/2474

**Additional Note:**
Single-artifact bump (`version.foundation` only), per the one-PR-per-artifact rule.

