### PR TITLE
OP-16359 [Android][Config] Bump version.foundation_auth to 5.0.53

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.5.3"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.52"
+version.foundation_auth = "5.0.53"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
**Ticket:** [OP-16359](https://endios.atlassian.net/browse/OP-16359)

**Purpose of this Pull Request:**

Bumps `version.foundation_auth` to 5.0.53 to pull in `LoginViewModel.requestMagicLink` now sending `magicLogin=true` in `deepLinkParameters`.

Companion to Auth PR endiosGmbH/endiosOneFoundation-Auth-Android#86. Merge only after Auth 5.0.53 has been published.

**Note on stacking with #724:**

endiosGmbH/Android-Config#724 is also open and bumps `version.foundation_auth` 5.0.51 → 5.0.52 (companion to Auth OP-16299). Whichever of #724 / this PR merges first, the other will need a trivial rebase. Once #724 is in, this PR's diff becomes 5.0.52 → 5.0.53.

`version.foundation` and `version.foundation_release` are unchanged.

**Additional Note:**

None.

**Deprecations (if any):**

None.

[OP-16359]: https://endios.atlassian.net/browse/OP-16359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ