### PR TITLE
OP-16694 Bump version.foundation to 5.5.8

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.7"
+version.foundation = "5.5.8"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.53"


### PR DESCRIPTION
**Ticket:** [OP-16694](https://endios.atlassian.net/browse/OP-16694 "Link to JIRA")

**Purpose of this Pull Request:**
Bumps `version.foundation` (LATEST) from 5.5.4 → **5.5.8** to pick up the Android 12+ splash-screen fix in Foundation. `version.foundation_release` (STABLE) is intentionally untouched.

Originally targeted 5.5.5, but 5.5.5 / 5.5.6 / 5.5.7 were taken on Foundation develop by OP-16360 / OP-16478 / AGENCY-7577; the Foundation PR (#856) re-bumped to **5.5.8**, so this version bump follows.

**⚠️ Merge order (this PR is step 3 of 4):**
1. **Android-Config catalog** (https://github.com/endiosGmbH/Android-Config/pull/733) → adds `dependency.ui.androidx_core_splashscreen`. ✅ Merged.
2. **Foundation** (https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/856) → publishes Foundation 5.5.8.
3. **Android-Config version bump — this PR (#732)** → merge only **after** Foundation 5.5.8 is published; repointing `version.foundation` before the artifact exists breaks every downstream build.
4. **endiosOneApp** (https://github.com/endiosGmbH/endiosOneApp-Android/pull/2476) → merge last.

**Additional Note:**
Separate from the catalog PR (#733) on purpose: the catalog entry must merge **before** Foundation builds, whereas this version bump must merge **after** 5.5.8 is published — opposite timing, so they cannot share a branch.

**Deprecations (if any):**
None.


[OP-16694]: https://endios.atlassian.net/browse/OP-16694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
