### PR TITLE
OP-16278 Bump version.foundation to 5.5.10

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.9"
+version.foundation = "5.5.10"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.53"


### PR DESCRIPTION
## Summary

- Bumps `version.foundation` (LATEST) from 5.5.9 → 5.5.10 to pick up [OP-16278](https://endios.atlassian.net/browse/OP-16278) (Foundation PR endiosGmbH/endiosOneFoundation-Android#857), which adds `endiosVersion` to every Android CloudEvent.
- `version.foundation_release` (STABLE) is untouched.

## Companion PRs

- endiosGmbH/endiosOneFoundation-Android#857 — Foundation implementation.

## Merge order

**Merge Foundation #857 first.** That PR publishes `5.5.10` to `mvn.endios.de` on merge; this PR then points `version.foundation` at the freshly-published artifact. Reversing the order opens a window where any app build against `develop` of Android-Config cannot resolve the Foundation dep.

## Version history context

Develop is now at `version.foundation = 5.5.9` after PR #732 (5.5.7 → 5.5.8, OP-16694) and PR #727 (5.5.8 → 5.5.9, OP-16772) both merged on 2026-06-03. This PR was originally drafted against develop at 5.5.7 (jumping straight to 5.5.9 to dodge an unmerged 5.5.8), then bumped to 5.5.10 after Foundation PR #857 was itself rebased (the previously-targeted 5.5.9 was claimed by OP-16772). Now rebased onto current develop with a clean single-line bump 5.5.9 → 5.5.10.

## Test plan

- [x] Diff is a single-line bump of `version.foundation` (5.5.9 → 5.5.10).
- [ ] After merge, an app pulling `version.foundation` resolves Foundation 5.5.10 and emits `data.endiosVersion = "5.5.10"` in CloudEvents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-16278]: https://endios.atlassian.net/browse/OP-16278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ