### PR TITLE
AGENCY-7576: Bump version.foundation to 5.5.16

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.14"
+version.foundation = "5.5.16"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) 5.5.8 → 5.5.9 to pick up [AGENCY-7576](https://endios.atlassian.net/browse/AGENCY-7576) (Foundation PR endiosGmbH/endiosOneFoundation-Android#858), which adds an optional `title` parameter to `GalleryBox`.
- `version.foundation_release` (STABLE) is untouched.

## Companion PRs
- endiosGmbH/endiosOneFoundation-Android#858 — Foundation implementation.

## Merge order
- Merge Foundation #858 first (it publishes 5.5.9 to Maven on merge); then this PR points `version.foundation` at the published artifact.

## Note
- PR #857 (OP-16278) also bumps Foundation to 5.5.9. Whichever Foundation PR merges second must rebump to 5.5.10; this config bump will be updated to match if that happens.

[AGENCY-7576]: https://endios.atlassian.net/browse/AGENCY-7576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ