### PR TITLE
OP-16360 Bump Foundation 5.5.18

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.17"
+version.foundation = "5.5.18"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"


### PR DESCRIPTION
**Ticket:** [OP-16360](https://endios.atlassian.net/browse/OP-16360 "Link to JIRA")

**Purpose of this Pull Request:**

Bumps the LATEST Foundation version (`version.foundation`) and the Auth version (`version.foundation_auth`) so apps pick up the magic-link autologin QA-fix.

- `version.foundation` 5.5.9 → 5.5.10
- `version.foundation_auth` 5.0.53 → 5.0.55

Foundation 5.5.10 ships:
1. The QA-fix: error dialog timing + post-error widget navigation, plus the three login funnel events (`USER_DECISION` / `CONVERSION_SUCCESS` / `SCREEN_VIEW`) on the magic-link autologin path.
2. Promotion of the four shared login funnel context strings into `one-core-analytics` and `parseErrorSubject` into `one-core-user`, so Foundation and Auth no longer duplicate them.

`foundation_auth` 5.0.55 is the Auth companion that switches its imports to the promoted symbols and removes the now-dead duplicates.

`version.foundation_release` is intentionally unchanged (STABLE; this is a develop-only bump).

**Companion PRs:**
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/859
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/87

**Additional Note:**

Merge order: Foundation #859 → Auth #87 (needs 5.5.10 published) → this PR. The 5.0.55 jump in `foundation_auth` skips 5.0.54 because Auth's develop already carried that pomVersion locally before this work; the OP-16299 PR that would have introduced 5.0.54 to Android-Config is still in flight (`feature/OP-16299-bump-foundation-auth`). If that lands first, rebase this PR to keep the numbers contiguous; otherwise the 5.0.54 artifact will be skipped from the public version line, which is fine.

**Deprecations (if any):**

None.

[OP-16360]: https://endios.atlassian.net/browse/OP-16360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ