### PR TITLE
OP-16299 [Android][Config] Bump version.foundation to 5.5.11 (401 interceptor revert)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.10"
+version.foundation = "5.5.11"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.54"


### PR DESCRIPTION
## What

Bumps `version.foundation` 5.5.10 → **5.5.11** — the version that reverts the global 401 interceptor (endiosGmbH/endiosOneFoundation-Android#860), per the team decision on [OP-16299](https://endios.atlassian.net/browse/OP-16299) to handle session expiry widget-side.

`version.foundation` only, per the one-PR-per-artifact rule.

## ⚠️ Merge gates (two)

1. endiosGmbH/endiosOneFoundation-Android#860 merged and develop CI has published `foundation:5.5.11`.
2. endiosGmbH/endiosOneFoundation-Auth-Android#88 **merged** — Auth develop still references `SessionEventBus` until then; pointing the catalog at the bus-less 5.5.11 earlier breaks every Auth build (incl. CI on open Auth PRs).

Note: open Android-Config #736 (OP-16360) also touches `version.foundation` — whichever lands second rebases trivially.

## Sequence

1. endiosGmbH/endiosOneFoundation-Android#860 → publishes `foundation:5.5.11`
2. endiosGmbH/endiosOneFoundation-Auth-Android#88 → publishes `platform-auth:5.0.55` (removes the bus references; merge-order-independent of step 1)
3. **This PR**
4. Android-Config #738 (`version.foundation_auth` → 5.0.55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-16299]: https://endios.atlassian.net/browse/OP-16299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ