### PR TITLE
OP-16299 [Android][Config] Bump version.foundation_auth to 5.0.55 (401 redirect revert)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.5.10"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.54"
+version.foundation_auth = "5.0.55"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## What

Bumps `version.foundation_auth` 5.0.54 → **5.0.55** — the version that reverts the Auth side of the global 401 → login flow (endiosGmbH/endiosOneFoundation-Auth-Android#88), per the team decision on [OP-16299](https://endios.atlassian.net/browse/OP-16299) to handle session expiry widget-side.

`version.foundation_auth` only, per the one-PR-per-artifact rule. (Branch name still says 5.0.56 from an earlier draft — content is 5.0.55.)

Note: open Auth draft #87 also targets 5.0.55 — whichever merges first wins the number; the other re-bumps.

## ⚠️ Merge gate

Merge **only after** endiosGmbH/endiosOneFoundation-Auth-Android#88 has merged and develop CI has published `platform-auth:5.0.55`.

## Sequence

1. endiosGmbH/endiosOneFoundation-Android#860 → publishes `foundation:5.5.11`
2. endiosGmbH/endiosOneFoundation-Auth-Android#88 → publishes `platform-auth:5.0.55` (must merge before Android-Config #737 — Auth develop references the removed bus until then)
3. Android-Config #737 (`version.foundation` → 5.5.11)
4. **This PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-16299]: https://endios.atlassian.net/browse/OP-16299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ