### PR TITLE
OP-16694 [Android][Config] Bump version.foundation to 5.5.12 (splash round 2)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.10"
+version.foundation = "5.5.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.54"


### PR DESCRIPTION
## What

Bumps `version.foundation` 5.5.11 → **5.5.12** — the version carrying OP-16694 round 2 (endiosGmbH/endiosOneFoundation-Android#861, hold splash through registration until config loads).

`version.foundation` only, per the one-PR-per-artifact rule.

## ⚠️ Merge gate

Merge **only after** #737 (5.5.11, OP-16299 revert) has merged — this PR re-targets the catalog line on top of it — and Foundation develop CI has published `foundation:5.5.12`.

Note: originally opened as 5.5.11; re-bumped to 5.5.12 after Foundation #860 (OP-16299 revert) merged first and took 5.5.11 (catalog companion: #737). Branch name retains the -5.5.11 suffix; renaming would close the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)