### PR TITLE
OP-15986 [Android-Config] Bump version.foundation to 5.5.13

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.12"
+version.foundation = "5.5.13"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"


### PR DESCRIPTION
Companion bump for [endiosOneFoundation-Android#862](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/862) — round 3 of OP-15986 (Gallery tile chevron resized to the 7×12 Figma spec).

Bumps `version.foundation` (LATEST) from 5.5.12 to 5.5.13. `version.foundation_release` (STABLE) is untouched.

**Merge order (this PR is #2):**
1. [`endiosOneFoundation-Android#862`](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/862) — CI publishes Foundation 5.5.13 on merge.
2. **This PR** — merge only after 5.5.13 is published, or every downstream build breaks in the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)