### PR TITLE
AGENCY-7610 [Android][Config] Add lottie-compose dependency

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -102,6 +102,8 @@ version.compose_material3 = "1.4.0"
 version.compose_runtime = "2.6.2"
 // Accompanist-compose
 version.accompanist = "0.30.1"
+// Lottie-compose
+version.lottie_compose = "6.7.1"
 // maps-compose
 version.maps_compose = "2.11.4"
 // end-dependency-version-declaration
@@ -223,6 +225,10 @@ lifecycle.runtime_ktx = "androidx.lifecycle:lifecycle-runtime-ktx:$version.andro
 lifecycle.viewmodel = "androidx.lifecycle:lifecycle-viewmodel-ktx:$version.androidx_lifecycle"
 lifecycle.navigation = "androidx.lifecycle:lifecycle-viewmodel-navigation3:$version.androidx_lifecycle"
 dependency.lifecycle = lifecycle
+
+def lottie = [:]
+lottie.compose = "com.airbnb.android:lottie-compose:$version.lottie_compose"
+dependency.lottie = lottie
 
 def mockk = [:]
 mockk.core = "io.mockk:mockk:$version.mockk"


### PR DESCRIPTION
## Summary
- Adds `com.airbnb.android:lottie-compose` (`6.7.1`) to `version.gradle` as `dependency.lottie.compose`.
- Centralizes the version so widget modules reference `dependency.lottie.compose` instead of a hardcoded coordinate.

## Context
Companion to the Lottie integration spike **AGENCY-7610** in `oneWidgetProfilePremium-Android` (`oneWidgetCssProfile`), which renders a Lottie in a widget tile via `lottie-compose`.

## Test plan
- Consuming widget module declares `implementation dependency.lottie.compose` and resolves `lottie-compose:6.7.1` once this lands on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)