### PR TITLE
AGENCY-7578: Bump version.foundation to 5.5.17

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.15"
+version.foundation = "5.5.17"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` (LATEST) 5.5.15 → 5.5.17 to pick up Foundation [#863](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/863) (AGENCY-7578), the GalleryBox 16:9 item style for the OW v2.0 Offer Detail View.
- Goes straight to **5.5.17** (skipping 5.5.16): #863 was rebased on top of the title-param PR (#858), so Foundation 5.5.17 is a **superset** that already contains AGENCY-7576's `title` param. The catalog value is just a pointer — nothing requires 5.5.16 to be referenced.
- `version.foundation_release` (STABLE) untouched.

## Supersedes
- **#735 (AGENCY-7576 → 5.5.16)** — no longer needed; its change is included in 5.5.17. Close #735.

## Companion PRs
- Foundation: endiosGmbH/endiosOneFoundation-Android#863 (merged, published 5.5.17)
- Offer World: endiosGmbH/oneWidgetOffers-Android#335
- Republish after merge: `oneWidgetEvents-Android`, `oneWidgetGarbageCalendar-Android`

🤖 Generated with [Claude Code](https://claude.com/claude-code)