### PR TITLE
AGENCY-7612 Bump version.foundation to 5.5.14

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.12"
+version.foundation = "5.5.13"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.13"
+version.foundation = "5.5.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` (LATEST) `5.5.12` → `5.5.13`.

Companion to **endiosOneFoundation-Android** — picks up `rememberSafeNavigate`, the forward counterpart to `rememberSafeNavigateBack` (guards against duplicate forward navigation in Nav3).

`version.foundation_release` (STABLE) untouched.

## Companion PRs
- endiosOneFoundation-Android: _linked from that PR_

🤖 Generated with [Claude Code](https://claude.com/claude-code)