### PR TITLE
chore: bump foundation_test_library to 5.0.11

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -55,7 +55,7 @@ version.foundation = "5.5.12"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"
-version.foundation_test_library = "5.0.10"
+version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"
 // google
 version.google_exoplayer = "2.17.1"


### PR DESCRIPTION
## Summary
Bumps `version.foundation_test_library` from `5.0.10` to `5.0.11` in `version.gradle`.

## Changes
- `version.foundation_test_library = "5.0.11"` (was `5.0.10`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)