### PR TITLE
OP-16490 [Android-Config] Bump version.foundation to 5.5.15

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.14"
+version.foundation = "5.5.15"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.55"


### PR DESCRIPTION
### OP-16490 — merge order (sequential; each step waits for the previous artifact to publish)
1. **Foundation** — endiosGmbH/endiosOneFoundation-Android#865 — gallery autoplay fix → publishes Foundation **5.5.15**
2. This PR
3. **Widget (oneWidgetOffers)** — endiosGmbH/oneWidgetOffers-Android#336 — main-media fix → publishes `oneWidgetOfferWorld` **5.0.1**
4. **endiosOneApp** — endiosGmbH/endiosOneApp-Android#2490 — pin `oneWidgetOfferWorld` → **5.0.1** (after 5.0.1 published; Foundation 5.5.15 via step 2)

⚠️ **Version coordination (resolved):** Foundation **5.5.13** was claimed by OP-15986 (endiosGmbH/endiosOneFoundation-Android#862 + endiosGmbH/Android-Config#740) and **5.5.14** by AGENCY-7612 (endiosGmbH/endiosOneFoundation-Android#864) — both merged to develop first, so OP-16490 re-bumped to develop + 1 = **5.5.15**. Foundation #865 and this PR merged develop in to resolve the version conflict.
⚠️ **RELEASE-TODO:** every step above must also be applied to **`release/v26.06`** (June26 release).

---

Companion to Foundation endiosGmbH/endiosOneFoundation-Android#865 (OP-16490 — detail gallery videos no longer autoplay). Bumps `version.foundation` → **5.5.15** so consumers pick up the fix.

⚠️ Merge **only after** Foundation 5.5.15 is published (step 1), per the order above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
