### PR TITLE
Bump foundation_release to 5.5.12-RC (release/v26.06)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.12"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.22-RC"
+version.foundation_release = "5.5.12-RC"
 version.foundation_auth = "5.0.55"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Why
`version.foundation_release` (the stable foundation used by `release/*` branches) was stale at `5.4.22-RC`. That predates `NotificationConstants` / `trackNotificationEvent`, so the app's `release/v26.06` build fails Kotlin compile on Jenkins. Foundation's `release/v26.06` is at `5.5.12`; #867 publishes it as `5.5.12-RC`.

## What
- `version.gradle`: `version.foundation_release` `5.4.22-RC` → `5.5.12-RC`

## Merge order
1. [Foundation #867](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/867) — `pomVersion` → `5.5.12-RC`, publishes the RC artifact
2. **This PR** (Android-Config) — `version.foundation_release` → `5.5.12-RC`

⚠️ Do **not** merge until #867 is merged and `5.5.12-RC` is published — merging early breaks every `release/v26.06` build (artifact won't resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)