### PR TITLE
OP-16360 Bump foundation_auth 5.0.56

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.5.14"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.55"
+version.foundation_auth = "5.0.56"
 version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Follow-up split-out from #736 to break the chicken-and-egg between the Foundation bump (needs to land first so Auth CI sees `foundation = 5.5.16`) and the Auth bump (needs Auth `5.0.56` already on Maven before `version.foundation_auth` points at it).
- Single-line change: `version.foundation_auth` `5.0.55` → `5.0.56`.

## Merge order
1. endiosOneFoundation-Android #859 → publishes Foundation `5.5.16`.
2. Android-Config #736 → develop `foundation = 5.5.16`.
3. endiosOneFoundation-Auth-Android #87 → CI compiles against `5.5.16` (importing the promoted `LoginAnalyticsConstants` + `parseErrorSubject`), publishes Auth `5.0.56`.
4. **This PR** → develop `foundation_auth = 5.0.56`, consumers pick up the new Auth at the next config refresh.

## Test plan
- [ ] Wait for Auth `5.0.56` to be published to `mvn.endios.de` before flipping this PR out of draft.
- [ ] After merge, app + widget builds resolve Auth `5.0.56` without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)