### PR TITLE
OP-16024 [Android][Auth] Bump foundation_auth to 5.0.57

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.5.18"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.55"
+version.foundation_auth = "5.0.57"
 version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
- Bump `foundation_auth` from `5.0.55` → `5.0.57` to pick up the OAuth/PKCE register analytics re-implementation that sources the register URL from `credentials.register.fields[0].url`.

## Companion PR
- Auth: https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/90

## Context
The original OP-16024 work was reverted in [OP-16290](https://endios.atlassian.net/browse/OP-16290). This follow-up re-enables the register-funnel analytics for WEB_PKCE apps using an existing dashboard convention (URL in the first field of the register layout) — no Foundation model change, no binary-compat risk.

## Test plan
- [ ] CI green
- [ ] Once merged, build any WEB_PKCE app with `register.fields[0].url` configured (Gronau Test is already set up) and verify Firebase analytics fire on register navigation in the OAuth webview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-16290]: https://endios.atlassian.net/browse/OP-16290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ