### PR TITLE
OP-16506 [Android][Config] Bump version.foundation to 5.5.19

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.18"
+version.foundation = "5.5.19"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.56"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.19"
+version.foundation = "5.5.20"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.56"


### PR DESCRIPTION
## Summary

- Bumps `version.foundation` (LATEST) `5.5.19` → `5.5.20` for [OP-16506](https://endios.atlassian.net/browse/OP-16506).
- `version.foundation_release` (STABLE) is untouched.
- (Re-bumped from 5.5.19 → 5.5.20 after AGENCY-7573 claimed 5.5.19 on develop first.)

## Companion PRs

- Foundation: endiosGmbH/endiosOneFoundation-Android#868 (the fix that publishes `5.5.20`)

## Merge order

1. endiosGmbH/endiosOneFoundation-Android#868 — must merge first; develop CI publishes Foundation `5.5.20`.
2. **This PR** — merge only **after** `5.5.20` is published, otherwise every downstream build breaks in the gap.


[OP-16506]: https://endios.atlassian.net/browse/OP-16506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ