### PR TITLE
OP-16360 Bump Foundation to 5.5.22

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.19"
+version.foundation = "5.5.20"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.56"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.21"
+version.foundation = "5.5.22"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.56"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.20"
+version.foundation = "5.5.21"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.56"


### PR DESCRIPTION
## Summary
- Bumps \`version.foundation\` from 5.5.19 → 5.5.21 (LATEST only — \`version.foundation_release\` STABLE unchanged).
- Note: 5.5.20 was claimed by [PR #868](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/868) (OP-16506 overlay deeplink) which merged before this one; this PR steps over to 5.5.21.

## Companion PRs
- [endiosOneFoundation-Android#869](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/869) — Magic-link autologin auth-error dialog now surfaces the BE-provided \`subject\` + \`body\` instead of the generic Foundation strings (QA round #3).

## Test plan
- [ ] Foundation #869 merges first → 5.5.21 published → this PR merges so the develop app picks the new artifact up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)