### PR TITLE
OP-16360 release/v26.06: foundation_release -> 5.5.12-RC2

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.12"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.13-RC"
+version.foundation_release = "5.5.12-RC2"
 version.foundation_auth = "5.0.55-RC"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"

--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.12"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.12-RC"
+version.foundation_release = "5.5.13-RC"
 version.foundation_auth = "5.0.55-RC"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation_release` from 5.5.12-RC → 5.5.13-RC on `release/v26.06`.

## Companion PRs
- [endiosOneFoundation-Android#870](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/870) — cherry-picks the OP-16360 magic-link autologin work (QA-fix #2 from develop PR #859 + QA-fix #3 from develop PR #869) onto `release/v26.06`.

## Test plan
- [ ] Foundation #870 merges first → 5.5.13-RC is published → this PR merges so the release-branch app build picks up the new artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)