### PR TITLE
OP-16506 [Android][Config] Bump version.foundation to 5.5.23

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.22"
+version.foundation = "5.5.23"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"


### PR DESCRIPTION
## Why

Companion to the Foundation fix for **OP-16506** (deeplink-opened widget showed login instead of the target widget's `WIDGET` overlay — an activity-launch race). Points `version.foundation` at the newly published Foundation **5.5.23**.

## What

- `version.gradle`: `version.foundation` `5.5.22` → `5.5.23`.

## Merge order

This bump must merge **only after** Foundation 5.5.23 has been published — repos pull this catalog at build time, so merging early breaks every downstream build in the gap.

1. [endiosOneFoundation-Android#872](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/872) — merge & publish Foundation 5.5.23 first
2. **This PR** — bump `version.foundation` → 5.5.23 (merge after #872 publishes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)