### PR TITLE
AGENCY-7668: Bump version.foundation to 5.5.23

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.22"
+version.foundation = "5.5.23"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"


### PR DESCRIPTION
Bumps `version.foundation` (LATEST) `5.5.22` → `5.5.23` to pick up the image-tile title color fix.

Companion to: endiosGmbH/endiosOneFoundation-Android#874 ([AGENCY-7668](https://endios.atlassian.net/browse/AGENCY-7668)).

`version.foundation_release` (STABLE) is untouched.

[AGENCY-7668]: https://endios.atlassian.net/browse/AGENCY-7668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ