### PR TITLE
AGENCY-7674 [Android][Config] Bump Retrofit to 3.0.0 and OkHttp to 4.12.0

### DIFF
--- a/.ai/specs/AGENCY-7674.md
+++ b/.ai/specs/AGENCY-7674.md
@@ -1,0 +1,59 @@
+# Spec: Bump Retrofit to 3.x and OkHttp to 4.12.x
+
+**Ticket:** [AGENCY-7674](https://endios.atlassian.net/browse/AGENCY-7674)
+**Created:** 2026-06-16
+**Status:** Implemented
+
+## Context
+
+Phase 0a of the Gson → kotlinx-serialization migration (Epic [OP-16714](https://endios.atlassian.net/browse/OP-16714)). The official `converter-kotlinx-serialization` adapter requires Retrofit ≥ 2.10, so the network stack must move off Retrofit 2.6.1 before the migration can begin. Going straight to 3.0.0 is essentially free: the `retrofit2.*` package and Maven coordinate are unchanged, 3.x is forward binary-compatible with 2.x, and its only hard new requirement — OkHttp ≥ 4.12 — is bumped here anyway. Independent of the migration, the bump pulls in 5+ years of bug fixes and security patches.
+
+This Story is the **Android-Config layer only** — the single `version.gradle` constant change that gates everything downstream. Foundation rebuild + patch-release and the per-widget bumps are tracked as follow-on work (they are blocked on a published Foundation artifact and cannot proceed until this lands).
+
+## Requirements
+
+### Functional
+- `version.gradle` declares `version.retrofit = "3.0.0"` (was `2.6.1`).
+- `version.gradle` declares `version.okhttp = "4.12.0"` (was `4.9.1`).
+- No other version constant changes; Gson and its Retrofit converter stay untouched (removed in a later phase).
+
+### Non-Functional
+- No source-level change required in any consuming repo — `retrofit2.*` and `okhttp3.*` imports must continue to resolve unchanged.
+
+## Behaviors
+
+This is a build-configuration constant change with no testable runtime behavior, so there is no red-green-refactor cycle. Correctness is established by the upfront API audit (below) and verified downstream by Foundation/widget CI compiling against the new versions.
+
+- [x] Audit every consuming repo for Retrofit/OkHttp APIs removed or changed between the old and new versions.
+- [x] `version.gradle` shows Retrofit `3.0.0` and OkHttp `4.12.0`.
+
+## API Audit (Work step 1)
+
+Audited Foundation, Auth, and all ~26 `oneWidget*-Android` repos for the APIs the ticket flagged as at-risk across Retrofit 2.6 → 3.0:
+
+| Flagged API | Occurrences | Verdict |
+|---|---|---|
+| `Retrofit.Builder#callFactory` | 0 | Not used |
+| `retrofit2.Call#enqueue(Callback)` | 0 | All `.enqueue(` hits are `WorkManager` / Foundation's own `Requester` DSL, not Retrofit |
+| `MoshiConverterFactory` (changed ctors) | 0 | Not used — the stack uses `GsonConverterFactory` |
+
+Retrofit is wired in a single place — `endiosOneFoundation-Android/one-core-network/.../service/internal/IOService.kt` — using only `Retrofit.Builder().client(...).addConverterFactory(GsonConverterFactory.create()).baseUrl(...)` plus `.create()`. All of these are source-compatible in Retrofit 3.0.
+
+OkHttp usage (`OkHttpClient.Builder`, `Cache`, `Interceptor`/`Interceptor.Chain`, `HttpLoggingInterceptor`, `Response`, `request.url.host`) is stable within the 4.x line; 4.9 → 4.12 introduces no breaking changes.
+
+**Conclusion:** no source change required in any repo. Risk confirmed low, matching the ticket's assessment.
+
+## Technical Notes
+
+- **Affected files/modules:** `Android-Config/version.gradle` (two lines).
+- **Base branch:** `develop`. Android-Config's GitHub default is `master`, so `--base develop` must be passed explicitly; the app reads `version.gradle` from the branch it resolves against.
+- **No CHANGELOG / no pomVersion:** Android-Config publishes no versioned artifact and has no `CHANGELOG.md`.
+- **Downstream (out of scope here):** Foundation must rebuild against the new versions and patch-release before any widget repo can bump Foundation. Widget bumps then proceed in parallel. Each consuming widget gets a device smoke test focused on network paths.
+
+## Open Questions
+
+- None. Scope, target versions, and base branch are unambiguous in the ticket.
+
+## QA
+
+**Recommended app:** _Not applicable to this PR._ The Android-Config change is a `version.gradle` constant bump — there is no buildable/runnable artifact to QA locally. Network-path smoke testing (request/response, cache, interceptors, timeouts) happens downstream, per widget, once Foundation is rebuilt and the widgets bump to it — that is where `/qa-local` applies. Fallback app for that downstream testing is CSS 2.0 (`de.endios.one.css`).

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .idea/*
 *.iml
+.ai/status.json

--- a/version.gradle
+++ b/version.gradle
@@ -82,14 +82,14 @@ version.koin = "4.1.1"
 // mockk
 version.mockk = "1.13.5"
 // okhttp
-version.okhttp = "4.9.1"
+version.okhttp = "4.12.0"
 // permission
 version.permission = "4.8.0"
 // play-services
 version.play_services_maps = "18.1.0"
 version.play_services_location = "21.0.0"
 // retrofit
-version.retrofit = "2.6.1"
+version.retrofit = "3.0.0"
 // vertx-codegen
 version.vertx_codegen = "3.6.0"
 // jetpack-compose


### PR DESCRIPTION
**Ticket:** [AGENCY-7674](https://endios.atlassian.net/browse/AGENCY-7674 "Link to JIRA")

**Purpose of this Pull Request:**

Phase 0a of the Gson → kotlinx-serialization migration (Epic [OP-16714](https://endios.atlassian.net/browse/OP-16714)). Bumps the shared version constants so all consuming repos pick up Retrofit 3.0.0 and OkHttp 4.12.0 on their next build.

## Summary

- Bumps `version.retrofit` from `2.6.1` → `3.0.0` — first stable Retrofit 3.x release. The `retrofit2.*` package name is unchanged; no widget import edits needed.
- Bumps `version.okhttp` from `4.9.1` → `4.12.0` — latest stable in the 4.12.x line. Required by Retrofit 3.x and pulls in 3 years of OkHttp bug fixes and security patches.
- No source logic change — purely version constants in `version.gradle`.

## Companion PRs

- **endiosOneFoundation-Android #875:** [Bump Retrofit to 3.0.0 and OkHttp to 4.12.0](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/875) — aligns `mockwebserver` test dependency to `4.12.0`, bumps `pomVersion` to `5.5.24`. Merge after this PR.
- **Android-Config (Foundation version bump) #756:** [Bump version.foundation to 5.5.24](https://github.com/endiosGmbH/Android-Config/pull/756) — merge after Foundation 5.5.24 is published.

## Linked tickets consulted for context

- [AGENCY-7674](https://endios.atlassian.net/browse/AGENCY-7674) — Phase 0a: Bump Retrofit to 3.x and OkHttp to 4.12.x. Full AC and risk assessment in the ticket.
- [OP-16714](https://endios.atlassian.net/browse/OP-16714) — Epic: Gson → kotlinx-serialization migration. The `converter-kotlinx-serialization` adapter requires Retrofit ≥ 2.10, so this bump is a gate for the migration chain.

## Out-of-scope siblings (same symbol, intentionally not touched)

`version.foundation_release` (STABLE key) — untouched; this is a develop-branch flow. The Foundation rebuild and widget version bumps are follow-on steps after this PR merges.

## Backend implications

None — verified mobile-side fix is sufficient. Retrofit/OkHttp are client-side networking libraries with no backend protocol change.

## Test plan

1. After merge, trigger a Foundation CI run to confirm `assembleDebug` is green with Retrofit 3.0.0 + OkHttp 4.12.0 (already verified locally — BUILD SUCCESSFUL in 8m; zero Retrofit/OkHttp deprecation warnings).
2. Retrofit API audit results (logged on the Jira ticket): `callFactory` — 0 usages; `MoshiConverterFactory` — 0 usages. Foundation uses only `Retrofit.Builder().client().addConverterFactory(GsonConverterFactory).baseUrl().build()` — all standard 3.x methods.
3. Smoke test any widget's networking path after the full release chain completes (Foundation patch-release → widget version bump).

## Checklist

- [x] Multi-surface check: `version.gradle` constants only — no widget source files require changes. All `retrofit2.*` imports remain valid in Retrofit 3.x.
- [x] Cross-tier check: client-side dependency version bump — no backend involvement.

**Additional Note:**

Merge order: this PR → Foundation #875 (publish 5.5.24) → Android-Config Foundation-bump PR #756.

**Deprecations (if any):**

None. Retrofit 3.x is forward binary-compatible with 2.x per Square's stated guarantee.

[AGENCY-7674]: https://endios.atlassian.net/browse/AGENCY-7674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-16714]: https://endios.atlassian.net/browse/OP-16714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGENCY-7674]: https://endios.atlassian.net/browse/AGENCY-7674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ