### PR TITLE
AGENCY-7628 [Android][Config] Bump version.foundation to 5.5.24

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.23"
+version.foundation = "5.5.24"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Companion bump for [endiosOneFoundation-Android#866](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/866) — `AGENCY-7628: Contrast status bar text against the visible background on Android 15+`.

`version.foundation` → `5.5.24` (LATEST development version).

**Additional Note:**

- `version.foundation_release` (STABLE) is intentionally untouched.
- Target branch is `develop` per Android team trunk convention.

**Test plan:**

- After the Foundation PR merges and Foundation `5.5.24` is published, this bump points the LATEST line at it; verify a clean `endiosOneApp-Android` sync resolves Foundation `5.5.24` from the published repo.