### PR TITLE
OP-16490 [Android][Config] Bump version.foundation to 5.5.25

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.24"
+version.foundation = "5.5.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"


### PR DESCRIPTION
## What
Bumps `version.foundation` `5.5.24` → `5.5.25` to pick up the OP-16490 gallery-video QA-fix.

Companion to **endiosOneFoundation-Android [#878](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/878)** (stop gallery video on background/leave + fix fullscreen double-audio).

## Merge order
1. Foundation [#878](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/878) — must merge and **publish 5.5.25** to maven first
2. **This PR** — bumps the catalog to 5.5.25 (only after the artifact exists, or every downstream build breaks in the gap)

> ⚠️ **RELEASE-REQUIRED:** OP-16490 is release-blocking — the equivalent bump must also reach the June26 release branch once develop is reviewed/tested.
