### PR TITLE
AGENCY-7675: Add converter-kotlinx-serialization dependency coordinate

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -247,6 +247,7 @@ network.okhttp_base = "com.squareup.okhttp3:okhttp:$version.okhttp"
 network.okhttp_logging_interceptor = "com.squareup.okhttp3:logging-interceptor:$version.okhttp"
 network.retrofit_base = "com.squareup.retrofit2:retrofit:$version.retrofit"
 network.retrofit_converter_gson = "com.squareup.retrofit2:converter-gson:$version.retrofit"
+network.retrofit_converter_kotlinx = "com.squareup.retrofit2:converter-kotlinx-serialization:$version.retrofit"
 network.work_manager = "androidx.work:work-runtime-ktx:$version.work_manager"
 network.work_manager_testing = "androidx.work:work-testing:$version.work_manager"
 dependency.network = network


### PR DESCRIPTION
## Summary
- Add the `converter-kotlinx-serialization` Maven coordinate (`com.squareup.retrofit2:converter-kotlinx-serialization:$version.retrofit` → `3.0.0`) to `version.gradle`.
- Phase 0b of the Gson → kotlinx-serialization migration ([AGENCY-7675](https://endios.atlassian.net/browse/AGENCY-7675), Epic [OP-16714](https://endios.atlassian.net/browse/OP-16714)). Foundation's `one-core-network` consumes this coordinate to register a kotlinx converter alongside the existing Gson converter.
- The Retrofit `3.0.0` / OkHttp `4.12.0` / `kotlinx-serialization-json` deps this builds on are already on `develop` (Phase 0a, AGENCY-7674).

## Companion PRs
- Foundation: `endiosOneFoundation-Android` `feature/AGENCY-7675` (to follow).

## Merge order
- **This PR must merge to `develop` first.** Foundation resolves `Android-Config/develop/version.gradle` live, so its build/CI can only resolve the new coordinate once this lands.

## Test plan
- Additive version coordinate only; consumed and verified in the Foundation companion PR (build + kotlinx smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AGENCY-7675]: https://endios.atlassian.net/browse/AGENCY-7675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-16714]: https://endios.atlassian.net/browse/OP-16714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ