### PR TITLE
OP-16643 Bump version.foundation to 5.5.25

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.24"
+version.foundation = "5.5.25"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.25"
+version.foundation = "5.5.26"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"


### PR DESCRIPTION
**Purpose of this Pull Request:**

OP-16643 — Bump `version.foundation` (LATEST) `5.5.24` → `5.5.25`, picking up the gallery tile `title()` setter from [endiosOneFoundation-Android #881](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/881).

`version.foundation_release` (STABLE) is untouched.

## Merge order
1. [endiosOneFoundation-Android #881](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/881) — must publish `5.5.25` first
2. **This PR** — bumps the catalog
3. [oneWidgetOffers-Android #339](https://github.com/endiosGmbH/oneWidgetOffers-Android/pull/339) — consumes `5.5.25`; bumps widget → `5.0.8`
4. [endiosOneApp-Android #2510](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2510) — app → `oneWidgetOfferWorld 5.0.8`, after #339 publishes

> Note: #875 / #878 also target `5.5.25`. Whichever Foundation PR publishes the number first wins it; this bump tracks that published value.

**Additional Note:**

**Deprecations (if any):**

None.
