### PR TITLE
OP-16490 [Android-Config] version.foundation_release → 5.5.12-RC3

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.12"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.12-RC2"
+version.foundation_release = "5.5.12-RC3"
 version.foundation_auth = "5.0.55-RC"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
Points `release/v26.06` builds at Foundation **5.5.12-RC3**, which carries the OP-16490 detail-view gallery/fullscreen video fix.

`version.foundation_release`: `5.5.12-RC2` → `5.5.12-RC3`.

⚠️ **Merge only AFTER** Foundation `5.5.12-RC3` has published (else release builds break in the gap).

## Merge order
(Full URLs — bare `#nnn` would resolve within this repo, not the companion repos.)

1. Foundation — gallery/fullscreen fix → publishes `5.5.12-RC3` ✅ merged: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/884
2. **This PR** (Android-Config) — `version.foundation_release` → `5.5.12-RC3` (merge after #1 publishes)
3. oneWidgetOffers — main-media fix → publishes `oneWidgetOfferWorld` `5.0.0-RC3`: https://github.com/endiosGmbH/oneWidgetOffers-Android/pull/348
4. endiosOneApp — `oneWidgetOfferWorld` → `5.0.0-RC3` (merge after #3 publishes): https://github.com/endiosGmbH/endiosOneApp-Android/pull/2535

🤖 Generated with [Claude Code](https://claude.com/claude-code)