### PR TITLE
OP-16299 [Android][Config] Bump version.foundation to 5.5.28

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.27"
+version.foundation = "5.5.28"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"


### PR DESCRIPTION
## Summary
Bumps `version.foundation` (LATEST) → **5.5.28** for OP-16299 (opt-in session-expiry handling). `version.foundation_release` is untouched.

Merge only **after** `foundation:5.5.28` has been published by Foundation develop CI — pointing the catalog at an unpublished artifact breaks every downstream build.

## Merge order
Publish-gated — each step merges only after the previous artifact is published:
1. [Foundation #885](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/885) — publishes `foundation:5.5.28`
2. [Android-Config #765](https://github.com/endiosGmbH/Android-Config/pull/765) — `version.foundation` → 5.5.28 (after #885 publishes)  ← **This PR**
3. [Auth #91](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/91) — publishes `platform-auth:5.0.58` (after #765 merges)
4. [Android-Config #766](https://github.com/endiosGmbH/Android-Config/pull/766) — `version.foundation_auth` → 5.0.58 (after #91 publishes)
5. [endiosOneApp #2563](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2563) — register `SessionExpiryActivityObserver` (after #765)

_Widget opt-ins (HEMS / Profile / Invoices2) are on-demand and ship separately, per widget._
