### PR TITLE
OP-16299 [Android][Config] Bump version.foundation_auth to 5.0.58

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.5.27"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
-version.foundation_auth = "5.0.57"
+version.foundation_auth = "5.0.58"
 version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## Summary
Bumps `version.foundation_auth` (LATEST) → **5.0.58** for OP-16299 (LoginSucceeded emission). `version.foundation_auth_release` is untouched.

Merge only **after** `platform-auth:5.0.58` has been published by Auth develop CI.

## Merge order
Publish-gated — each step merges only after the previous artifact is published:
1. [Foundation #885](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/885) — publishes `foundation:5.5.28`
2. [Android-Config #765](https://github.com/endiosGmbH/Android-Config/pull/765) — `version.foundation` → 5.5.28 (after #885 publishes)
3. [Auth #91](https://github.com/endiosGmbH/endiosOneFoundation-Auth-Android/pull/91) — publishes `platform-auth:5.0.58` (after #765 merges)
4. [Android-Config #766](https://github.com/endiosGmbH/Android-Config/pull/766) — `version.foundation_auth` → 5.0.58 (after #91 publishes)  ← **This PR**
5. [endiosOneApp #2563](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2563) — register `SessionExpiryActivityObserver` (after #765)

_Widget opt-ins (HEMS / Profile / Invoices2) are on-demand and ship separately, per widget._
