### PR TITLE
OP-17077 [Android][Config] Bump version.foundation to 5.5.29

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.28"
+version.foundation = "5.5.29"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.57"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Point downstream builds at Foundation **5.5.29** (LATEST), which adds the shared Lottie tile player ([OP-17077](https://endios.atlassian.net/browse/OP-17077)).

- Bumps `version.foundation` 5.5.28 → 5.5.29. `version.foundation_release` (STABLE) untouched.

## Merge order

Publish-gated — each step merges only after the previous artifact is published:
1. [Android-Config #741](https://github.com/endiosGmbH/Android-Config/pull/741) — adds `dependency.lottie.compose` (prereq for the Foundation build). ✅ merged
2. [endiosOneFoundation-Android #886](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/886) — must merge to `develop` and **publish 5.5.29** first.
3. [Android-Config #767](https://github.com/endiosGmbH/Android-Config/pull/767) — `version.foundation` → 5.5.29 (only after 5.5.29 is on the maven repo, else downstream builds break in the gap). ← **This PR**

**Additional Note:**

Companion to endiosOneFoundation-Android #886.

**Deprecations (if any):**

None.


[OP-17077]: https://endios.atlassian.net/browse/OP-17077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
