### PR TITLE
AGENCY-7778 Bump version.foundation to 5.5.29

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.28"
+version.foundation = "5.5.29"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
Bumps `version.foundation` (LATEST) 5.5.28 → 5.5.29 for the `DomainResult.Error.Timeout` variant.

Companion to endiosGmbH/endiosOneFoundation-Android#887.

`version.foundation_release` (STABLE) is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)