### PR TITLE
OP-17065 [Android][Config] Bump version.foundation to 5.5.30

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.29"
+version.foundation = "5.5.30"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bump `version.foundation` (LATEST) `5.5.28` → `5.5.30` to pick up the OP-17065 Foundation deprecation release.

Companion to Foundation PR endiosGmbH/endiosOneFoundation-Android#890.

`version.foundation_release` (STABLE) is untouched.

## Merge order

1. Foundation endiosGmbH/endiosOneFoundation-Android#890 — merge & publish **first**
2. **This PR** — merge only after 5.5.30 is published, else downstream builds break
