### PR TITLE
OP-17077 [Android][Config] Bump version.foundation to 5.5.31

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.30"
+version.foundation = "5.5.31"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## What

```diff
 // foundation - LATEST development version
-version.foundation = "5.5.30"
+version.foundation = "5.5.31"
```

## Why

Foundation 5.5.31 (PR #891, merged) adds `TileType.TILE_TYPE_LOTTIE`, merges the lottie tile into `one-ui-tile` (so it reaches every widget via `foundation`), and adds the `lottieReplay` key. Widgets need 5.5.31 to route the lottie tile.

**No catalog coordinate** — the earlier `foundation.tile_lottie` coord was dropped: with the tile merged into `one-ui-tile` it's no longer a separate artifact, so nothing to reference. Widgets get it transitively via `foundation`.

## Version note

5.5.31 = re-bump after OP-17065 (#890/#769) took 5.5.30. OP-17065 #769 has merged, so develop is now at 5.5.30; this PR lands at 5.5.31 (cumulative — 5.5.31 includes #890's deprecations).

## Merge order
1. ~~[Foundation #891](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/891)~~ — ✅ merged; published 5.5.31.
2. ~~[OP-17065 Config #769](https://github.com/endiosGmbH/Android-Config/pull/769)~~ — ✅ merged; develop at 5.5.30.
3. **This PR** — `version.foundation` → 5.5.31 (unblocked).
4. [oneWidgetInvoices #155](https://github.com/endiosGmbH/oneWidgetInvoices-Android/pull/155) — routing branch only; 4.3.11.
5. [endiosOneApp #2569](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2569) — bump Invoice ref → 4.3.11.

Part of OP-17077 (AC #5 QA-surface wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
