### PR TITLE
OP-16239 [Android][Config] Bump version.foundation to 5.5.32

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.31"
+version.foundation = "5.5.32"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Point `version.foundation` (LATEST) to **5.5.32**, the Foundation build that introduces the reusable `OneTabBar` component (OP-16239). `version.foundation_release` (STABLE) is untouched.

## Merge order
1. [endiosGmbH/endiosOneFoundation-Android#892](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/892) → merge to `develop`, let CI publish `5.5.32`.
2. **This PR** → merge only after `5.5.32` is published (and after any lower in-flight `version.foundation` bumps land, so LATEST only moves forward).

**Deprecations (if any):** None.