### PR TITLE
OP-16239 Bump version.foundation to 5.5.33 (TabBar fix)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.32"
+version.foundation = "5.5.33"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## What

Bump `version.foundation` 5.5.32 → **5.5.33** to pick up the OneTabBar visibility QA-fix.

Foundation 5.5.32 (OP-16239 `OneTabBar` refactor) introduced a regression where the bottom navigation bar does not render at all. Foundation **5.5.33** fixes it (the inner `OneTabLayout` inherited `android:visibility="gone"` from forwarded XML attrs; the wrapper now keeps it visible).

## Merge order

1. **endiosOneFoundation-Android #893** — the 5.5.33 fix (must merge **and publish** first).
2. **This PR** — `version.foundation` → 5.5.33 (merge only after 5.5.33 is on maven, or every downstream build breaks in the gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
