### PR TITLE
AGENCY-7741: Bump version.foundation to 5.5.40

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.39"
+version.foundation = "5.5.40"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
Companion to [endiosOneFoundation-Android#903](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/903) (follow-up to [#894](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/894)).

Bumps `version.foundation` `5.5.39` → `5.5.40` for [AGENCY-7741](https://endios.atlassian.net/browse/AGENCY-7741) — registers the CSS Consumption (Simple) widget (`one_widget_css_consumption_simple`) in the widget options menu of other CSS widgets.

PR #894 merged without its own `pomVersion` bump, so the fix rode on top of the 5.5.39 artifact cut for OP-16545 and could not be published as a distinct release. Foundation-Android #903 bumps `pomVersion` to `5.5.40` and this PR points `version.foundation` at that new artifact. Retargeted from the earlier 5.5.39 diff.

[AGENCY-7741]: https://endios.atlassian.net/browse/AGENCY-7741