### PR TITLE
OP-17111 [Android][Config] Bump version.foundation to 5.5.34

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.33"
+version.foundation = "5.5.34"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) 5.5.33 → 5.5.34 to pick up the additive info-row icon-config API (`OneItemInfoIconViewState.iconBackgroundColor` + `scaleType`, runtime setters on `OneItemInfoRowView`).
- `version.foundation_release` (STABLE) untouched.

## Merge order
1. endiosGmbH/endiosOneFoundation-Android#897 — merge & let develop CI publish 5.5.34.
2. **This PR** — only after 5.5.34 is on maven, else every downstream build breaks in the gap.

## Test plan
No code — version catalog bump only. Downstream apps/widgets resolve 5.5.34 after Foundation publishes.