### PR TITLE
ci: use Gradle wrapper for widget publish

### DIFF
--- a/.github/workflows/widget-publish.yml
+++ b/.github/workflows/widget-publish.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           for module in $(echo '${{ inputs.modules }}' | jq -r '.[]'); do
             echo "::group::Build :$module"
-            gradle :$module:build
+            ./gradlew :$module:build
             echo "::endgroup::"
             echo "::group::Publish :$module"
-            gradle :$module:publish
+            ./gradlew :$module:publish
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Problem

Every widget Maven publish to `develop` / `release/**` is currently failing. The shared `widget-publish.yml` workflow runs the runner's **preinstalled `gradle`**, which on `ubuntu-latest` is now **Gradle 9.6.0**. That release removed the internal API `org.gradle.api.problems.internal.InternalProblems` that AGP 8.x relies on, so `com.android.application` can't be applied and the build dies at `app/build.gradle:1` before any module is built.

```
> Plugin 'com.android.internal.application' relies on
  'org.gradle.api.problems.internal.InternalProblems', a Gradle internal API
  that was removed in Gradle 9.6.0.
```

This affects **all** widgets using this reusable workflow, not a single repo. First observed on oneWidgetInvoices publish run [28442309750](https://github.com/endiosGmbH/oneWidgetInvoices-Android/actions/runs/28442309750) (PR #156), and the earlier #155 run on 2026-06-26.

## Fix

Invoke `./gradlew` instead of the system `gradle`. The wrapper pins each repo's Gradle version (currently 8.14.3), so the build no longer depends on whatever Gradle the runner image happens to ship.

```diff
-            gradle :$module:build
+            ./gradlew :$module:build
...
-            gradle :$module:publish
+            ./gradlew :$module:publish
```

## Verification

After merge, re-run a widget publish (or push to develop) and confirm the build uses Gradle 8.14.3 and reaches the publish step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)