### PR TITLE
OP-16239 Bump version.foundation to 5.5.37

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.35"
+version.foundation = "5.5.37"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## What & why

Bump `version.foundation` `5.5.35` → `5.5.37` to pick up the OP-16239 TabBar `tabBar`-config styling regression fix.

Companion to [`endiosOneFoundation-Android` #901](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/901). After the 5.5.32 `OneTabBar` refactor the Home Screen TabBar ignored the app's `tabBar` config (background, active colour, text size/font); the fix re-applies the theme at `setTabs()` time, post-config.

Only `version.foundation` is touched (one artifact per PR).

## Merge order

1. [`endiosOneFoundation-Android` #901](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/901) — publishes Foundation `5.5.37` on merge to `develop`.
2. **This PR** (`Android-Config`) — `version.foundation` → 5.5.37; merge **only after** #901 has merged and `5.5.37` is published, or every downstream build breaks in the gap.
