### PR TITLE
OP-17159 [Android][CI] Remove flaky oss.sonatype.org snapshots repo from addRepositories

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -335,7 +335,6 @@ ext.dependency = dependency
 def addRepositories(RepositoryHandler handler) {
     handler.google()
     handler.mavenCentral()
-    handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     handler.maven {
         url 'https://mvn.endios.de/android'
         credentials {


### PR DESCRIPTION
## Summary
- Removes the `https://oss.sonatype.org/content/repositories/snapshots` repository from `addRepositories` in `version.gradle`.
- It was listed **before** `mvn.endios.de` (where endios artifacts actually live). endios deps aren't on Sonatype, and when Sonatype returns a `504`, Gradle disables the repo and aborts resolution before reaching `mvn.endios.de` — intermittently breaking **all** widget CI (`lint`/`tests`).
- Nothing depends on it: there are no `-SNAPSHOT` dependencies anywhere in the config. OSSRH / `oss.sonatype.org` is also being sunset by Sonatype.

Verified `foundation:5.5.38`, `foundation-ui:5.5.38`, `test-app:5.0.11` are all published (`HTTP 200`) on `mvn.endios.de` — this is purely a repo-list/infra fix, not a publishing issue.

## Test plan
- Re-run CI on a currently-failing widget PR (e.g. oneWidgetDipkoPool #108) after this merges to `develop` — dependency resolution should no longer hit Sonatype and should go green.

## Merge order
1. **This PR** — Android-Config repo-list fix. Merges to `develop`; widget builds pull `version.gradle` from `Android-Config/develop` at build time, so this must land first.
2. [oneWidgetDipkoPool #108](https://github.com/endiosGmbH/oneWidgetDipkoPool-Android/pull/108) (OP-17158) — re-run its CI after this merges.
3. [endiosOneApp #2577](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2577) — app version bump; merge after the widget publishes.
