### PR TITLE
OP-16545 [Android-Config] Bump version.foundation to 5.5.39

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.38"
+version.foundation = "5.5.39"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` (LATEST) `5.5.38` → `5.5.39` to pick up the BarChart x-axis label "Note"/caption text-style fix.
- `version.foundation_release` (STABLE) is untouched.

## Merge order
1. [endiosOneFoundation-Android#902](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/902) — Foundation 5.5.39 (must merge + publish first)
2. **This PR** — bump the catalog; merge only **after** 5.5.39 is published, or every downstream build breaks in the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)