### PR TITLE
OP-16545 Bump version.foundation to 5.5.41

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.40"
+version.foundation = "5.5.41"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bumps `version.foundation` (LATEST) `5.5.40` → `5.5.41` to pick up the BarChart rightmost x-axis label clamp fix.

Companion to endiosGmbH/endiosOneFoundation-Android#904 (OP-16545). Merge only **after** #904 is merged and Foundation 5.5.41 is published, or downstream builds break in the gap.

`version.foundation_release` (STABLE) is untouched.

**Additional Note:**

Re-bumped 5.5.40 → 5.5.41: `AGENCY-7741` took 5.5.40 on develop first, so this follows Foundation #904's re-bump to 5.5.41 per the "first to merge wins the number" convention.

**Deprecations (if any):**

None.

## Merge order

1. [endiosOneFoundation-Android#904](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/904) — Foundation 5.5.41 (merge + publish first)
2. **This PR** — `version.foundation` → 5.5.41
