### PR TITLE
OP-17185 [Android][Config] Bump version.foundation to 5.5.41

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.40"
+version.foundation = "5.5.42"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- `version.foundation` (LATEST) → **5.5.42**, picking up the clickable Lottie tile from Foundation #905.
- `version.foundation_release` (STABLE) untouched.

Ticket: [OP-17185](https://endios.atlassian.net/browse/OP-17185)

## ⚠️ Merge gate & version race
- Merge **only after** Foundation 5.5.42 is published (develop CI publishes on merge of #905).
- The 5.5.41 race resolved: OP-16545 (Foundation #904 / Android-Config #784) won 5.5.41 on develop, so this chain re-bumped to **5.5.42**.

[OP-17185]: https://endios.atlassian.net/browse/OP-17185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Merge order
1. [Foundation `endiosOneFoundation-Android` #905 — publish `foundation` 5.5.42](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/905)
2. [**This PR** — `version.foundation` → 5.5.42 (after Foundation publishes)](https://github.com/endiosGmbH/Android-Config/pull/785)
3. [`oneWidgetInvoices-Android` #158 — wire both providers, publish 4.3.14 (after Config lands + Foundation published)](https://github.com/endiosGmbH/oneWidgetInvoices-Android/pull/158)
4. [`endiosOneApp-Android` #2582 — bump `oneWidgetInvoices`/`2` → 4.3.14 (after widget publishes)](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2582)
