### PR TITLE
OP-17111 [Android][Config] Bump version.foundation to 5.5.43

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.42"
+version.foundation = "5.5.43"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) 5.5.42 → 5.5.43 for the OP-17111 contract step (info-row icon → Compose, `iconView` removed).
- Merge **only after** Foundation 5.5.43 has published, or downstream builds break in the gap.

## Merge order
1. [Foundation #906](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/906) — Foundation 5.5.43 (publishes on merge to develop).
2. **This PR** — Android-Config `version.foundation` → 5.5.43 (merge after Foundation publishes).
3. [Foundation-Check #21](https://github.com/endiosGmbH/endiosOneFoundation-Check-Android/pull/21) — adapt the info-row icon test to the ComposeView (merge after this catalog bump; test goes green post-publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)