### PR TITLE
OP-16545 [Android-Config] Bump version.foundation_release to 5.5.12-RC4 (release/v26.06)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.12"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.12-RC3"
+version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.55-RC"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## What
Points `release/v26.06` at Foundation **5.5.12-RC4**, which carries the QA-approved OP-16545 BarChart x-axis label fixes (Note-style labels + rightmost-label clamp) cherry-picked from develop PRs #902 + #904.

Single value changed: `version.foundation_release` `5.5.12-RC3` → `5.5.12-RC4`.

## Merge order
1. [Foundation: cherry-pick OP-16545 to release/v26.06 (5.5.12-RC4)](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/907) — merge first; CI publishes `5.5.12-RC4`.
2. **This PR** (`Android-Config` → `release/v26.06`) — merge only **after** Foundation `5.5.12-RC4` is published, else release builds break in the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
