### PR TITLE
OP-17204 [Android][CI] Add android-ci Jenkins shared library (PR-verify pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Android-Config
 Configuration for android projects. No keys or business logic.
+
+Also hosts the **`android-ci`** Jenkins shared pipeline library (`vars/`). See [docs/android-ci.md](docs/android-ci.md).

--- a/docs/android-ci.md
+++ b/docs/android-ci.md
@@ -1,0 +1,53 @@
+# android-ci — Jenkins shared library
+
+Shared pipeline steps for endios Android CI, hosted in this repo and registered in
+Jenkins under the logical name **`android-ci`**. Analogous to the iOS `ios-ci` library
+(OP-17160). First consumer: `endiosOneApp-Android` PR-verify (OP-17204).
+
+Jenkins reads `vars/`, `src/`, and `resources/` from the repo root; the rest of
+Android-Config (gradle scripts, `version.gradle`, `tooling/`) is ignored by the library.
+
+## Contents
+
+```
+vars/
+  androidPRVerify.groovy   # PR-verify pipeline (ktlint, detekt, lint, unit tests)
+  githubStatusWrap.groovy  # per-check GitHub commit-status wrapper
+```
+
+## Consuming it
+
+Repo `Jenkinsfile.prverify`:
+
+```groovy
+@Library('android-ci') _
+androidPRVerify()
+```
+
+Per-repo overrides (widgets/Foundation with different flavors):
+
+```groovy
+androidPRVerify(lintTask: 'lint', unitTestTask: 'testDebugUnitTest')
+```
+
+## Jenkins setup (one-time, infra)
+
+1. **Register the library** — *Manage Jenkins → System → Global Pipeline Libraries*:
+   name `android-ci`, default version `develop` (Android-Config's trunk), SCM = this repo.
+2. **Create a Multibranch Pipeline** job per consuming repo pointed at `Jenkinsfile.prverify`,
+   discovering **Pull Requests only** (not branches) to avoid duplicate builds.
+3. **Webhook:** point the consuming repo's GitHub webhook at
+   `https://bouncer.jenkins.endios.one/github-webhook` and set the shared secret.
+   Jenkins validates the HMAC — the bouncer does not.
+4. **Suppress the native status:** enable the *skip-notifications-trait* on the job so only
+   the `ci/jenkins: *` statuses show (not `continuous-integration/jenkins/pr-head`).
+5. **Branch protection:** once green, mark `ci/jenkins: ktlint|detekt|lint|tests` as required
+   and remove the CircleCI checks.
+
+## ⚠️ When Android-Config goes private
+
+This library is loaded from Android-Config over SCM. Once the repo is private, Jenkins can no
+longer fetch it anonymously — the Global Pipeline Library config **must** be given SCM checkout
+credentials (a machine user / deploy key / PAT with read access). Without them, every consuming
+job fails at library resolution before any stage runs. Update the library's *Source Code
+Management → Credentials* at the same time the repo visibility changes.

--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -1,0 +1,155 @@
+#!/usr/bin/env groovy
+
+/**
+ * Shared PR-verify pipeline for endios Android repos.
+ *
+ * Replaces the CircleCI `*_pr_verify` workflow: ktlint + detekt on the Kotlin
+ * changeset (vs the PR base branch), Android lint, and unit tests. Each check
+ * reports an independent `ci/jenkins: <check>` GitHub commit status.
+ *
+ * Usage — repo `Jenkinsfile.prverify`:
+ *
+ *   @Library('android-ci') _
+ *   androidPRVerify()
+ *
+ * Overridable config (defaults match endiosOneApp-Android):
+ *
+ *   androidPRVerify(
+ *     baseBranch   : 'develop',
+ *     ktlintVersion: '0.40.0',
+ *     detektVersion: '1.22.0',
+ *     detektConfig : 'tooling/.detekt/detekt-config.yml',
+ *     detektPlugin : 'tooling/.detekt/detekt-formatting-1.22.0.jar',
+ *     lintTask     : 'lintDevelopDebug',
+ *     unitTestTask : 'testDevelopDebugUnitTest',
+ *     agentLabel   : 'android',
+ *   )
+ *
+ * Note: suppressing the native `continuous-integration/jenkins/pr-head` status
+ * is a job-level trait (skip-notifications-trait plugin), configured on the
+ * Multibranch job — not here. HMAC webhook-secret validation is Jenkins-side too;
+ * the bouncer (bouncer.jenkins.endios.one) does not validate payloads.
+ */
+def call(Map config = [:]) {
+    Map cfg = [
+        baseBranch   : 'develop',
+        ktlintVersion: '0.40.0',
+        detektVersion: '1.22.0',
+        detektConfig : 'tooling/.detekt/detekt-config.yml',
+        detektPlugin : 'tooling/.detekt/detekt-formatting-1.22.0.jar',
+        lintTask     : 'lintDevelopDebug',
+        unitTestTask : 'testDevelopDebugUnitTest',
+        agentLabel   : 'android',
+    ] + config
+
+    pipeline {
+        agent { label cfg.agentLabel }
+
+        options {
+            skipDefaultCheckout()
+            disableConcurrentBuilds()
+            timeout(time: 45, unit: 'MINUTES')
+            buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '30'))
+        }
+
+        environment {
+            ANDROID_HOME     = '/Users/endiosworker/Library/Android/sdk'
+            ANDROID_SDK_ROOT = '/Users/endiosworker/Library/Android/sdk'
+            JAVA_HOME        = '/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home'
+            PATH             = "${JAVA_HOME}/bin:/opt/homebrew/bin:${env.PATH}"
+        }
+
+        stages {
+            stage('Checkout & Changeset') {
+                steps {
+                    // skipDefaultCheckout() is on, so check out explicitly (once).
+                    checkout scm
+
+                    withCredentials([
+                        string(credentialsId: 'MAVEN_USER', variable: 'MAVEN_USER'),
+                        string(credentialsId: 'MAVEN_PASS', variable: 'MAVEN_PASS'),
+                    ]) {
+                        sh '''
+                          cat > local.properties << EOF
+ENDIOS_DE_HTACCESS_USER=${MAVEN_USER}
+ENDIOS_DE_HTACCESS_PASSWORD=${MAVEN_PASS}
+EOF
+                        '''
+                    }
+
+                    // Make the base branch available for the diff without fetching every branch.
+                    sh "git fetch --no-tags --force origin ${cfg.baseBranch}:refs/remotes/origin/${cfg.baseBranch}"
+
+                    script {
+                        // Kotlin files changed on this PR vs the merge-base with the base branch.
+                        // Mirrors CircleCI's resolve_changeset (diff-filter=dr drops deletes/renames).
+                        env.KOTLIN_CHANGESET = sh(
+                            returnStdout: true,
+                            script: "git diff --name-only --diff-filter=dr --relative origin/${cfg.baseBranch}...HEAD | grep '\\.kt[s\"]\\?\$' || true"
+                        ).trim()
+                        echo "Kotlin changeset:\n${env.KOTLIN_CHANGESET ?: '(none)'}"
+                    }
+                }
+            }
+
+            stage('ktlint') {
+                steps {
+                    githubStatusWrap('ci/jenkins: ktlint') {
+                        script {
+                            if (!env.KOTLIN_CHANGESET?.trim()) {
+                                echo 'No Kotlin changes — skipping ktlint.'
+                            } else {
+                                sh """
+                                  curl -sSLO https://github.com/pinterest/ktlint/releases/download/${cfg.ktlintVersion}/ktlint
+                                  chmod a+x ktlint
+                                  echo "${env.KOTLIN_CHANGESET}" | xargs ./ktlint --android --relative --disabled_rules=import-ordering --color
+                                """
+                            }
+                        }
+                    }
+                }
+            }
+
+            stage('detekt') {
+                steps {
+                    githubStatusWrap('ci/jenkins: detekt') {
+                        script {
+                            if (!env.KOTLIN_CHANGESET?.trim()) {
+                                echo 'No Kotlin changes — skipping detekt.'
+                            } else {
+                                sh """
+                                  curl -sSLO https://github.com/detekt/detekt/releases/download/v${cfg.detektVersion}/detekt-cli-${cfg.detektVersion}.zip
+                                  unzip -o detekt-cli-${cfg.detektVersion}.zip
+                                  INPUT=\$(echo "${env.KOTLIN_CHANGESET}" | tr '\\n' ',')
+                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "\$INPUT"
+                                """
+                            }
+                        }
+                    }
+                }
+            }
+
+            stage('lint') {
+                steps {
+                    githubStatusWrap('ci/jenkins: lint') {
+                        sh "./gradlew ${cfg.lintTask}"
+                    }
+                }
+            }
+
+            stage('tests') {
+                steps {
+                    githubStatusWrap('ci/jenkins: tests') {
+                        sh "./gradlew ${cfg.unitTestTask}"
+                    }
+                }
+            }
+        }
+
+        post {
+            always {
+                sh 'rm -rf local.properties ktlint detekt-cli-*.zip detekt-cli-*/'
+            }
+        }
+    }
+}

--- a/vars/githubStatusWrap.groovy
+++ b/vars/githubStatusWrap.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/env groovy
+
+/**
+ * Runs `body` while reporting a single GitHub commit status under `context`
+ * (e.g. "ci/jenkins: ktlint"): PENDING before, SUCCESS on clean exit, FAILURE
+ * on throw. Repo + commit SHA are inferred from the checked-out SCM by the
+ * GitHub plugin's githubNotify step.
+ */
+def call(String context, Closure body) {
+    githubNotify context: context, status: 'PENDING', description: 'Running'
+    try {
+        body()
+        githubNotify context: context, status: 'SUCCESS', description: 'Passed'
+    } catch (err) {
+        githubNotify context: context, status: 'FAILURE', description: 'Failed'
+        throw err
+    }
+}


### PR DESCRIPTION
**Ticket:** [OP-17204](https://endios.atlassian.net/browse/OP-17204 "Link to JIRA")

**Purpose of this Pull Request:**

Adds the **`android-ci`** Jenkins shared pipeline library to Android-Config, backing the CircleCI → Jenkins CI migration ([OP-17204](https://endios.atlassian.net/browse/OP-17204); plan [OP-16167](https://endios.atlassian.net/browse/OP-16167), mirrors iOS [OP-17160](https://endios.atlassian.net/browse/OP-17160)).

- `vars/androidPRVerify.groovy` — the PR-verify pipeline: checkout (`skipDefaultCheckout` + scoped base-branch fetch), Kotlin changeset resolution vs the base branch, ktlint + detekt on the changeset (skip when empty), Android lint, unit tests — each wrapped in a `ci/jenkins: <check>` GitHub status.
- `vars/githubStatusWrap.groovy` — per-check PENDING→SUCCESS/FAILURE status helper.
- `docs/android-ci.md` — Jenkins setup (library registration, PRs-only Multibranch, bouncer webhook + HMAC secret, skip-pr-head trait, branch protection).

Registered in Jenkins under the logical name `android-ci` (the repo stays `Android-Config`). Jenkins only reads `vars/`; the gradle/config files are untouched.

Companion: [endiosOneApp-Android#2585](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2585) adds `Jenkinsfile.prverify` (`@Library('android-ci') _` + `androidPRVerify()`) and removes `.circleci/config.yml`. This PR must be merged + the library registered in Jenkins **before** that one runs.

**Additional Note:**

⚠️ **When Android-Config goes private:** the Global Pipeline Library config must be given SCM checkout credentials (machine user / deploy key / PAT), or every consuming job fails at library resolution. See the note in `docs/android-ci.md`. — This is Groovy/Jenkins config with no local test harness; verification is a live PR build on Jenkins.

**Deprecations (if any):** None.


[OP-17204]: https://endios.atlassian.net/browse/OP-17204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-17204]: https://endios.atlassian.net/browse/OP-17204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-16167]: https://endios.atlassian.net/browse/OP-16167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-17160]: https://endios.atlassian.net/browse/OP-17160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ