### PR TITLE
OP-17216 Bump version.foundation to 5.5.44

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.43"
+version.foundation = "5.5.44"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.4.22-RC"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bump \`version.foundation\` (LATEST) 5.5.43 → 5.5.44 to pick up the OP-17216 fix: the shared Foundation Lottie tile now brand-colours strokes as well as fills.

**Additional Note:**

\`version.foundation_release\` (STABLE) is untouched.

## Merge order
1. [endiosOneFoundation-Android #909](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/909) — the fix; must merge & publish 5.5.44 first.
2. **This PR** — points the catalog at 5.5.44 once published.

**Deprecations (if any):** None.