### PR TITLE
OP-16545 Update foundation_release to 5.5.12-RC4 (v26.06)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.43"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.4.22-RC"
+version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"
 version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Back-merge (v26.06)

Promote the released Foundation to STABLE on develop after finishing release v26.06.

- `version.foundation_release`: `5.4.22-RC` → `5.5.12-RC4`

LATEST (`version.foundation` = 5.5.43) and `version.foundation_auth` are develop's own and left untouched.