### PR TITLE
OP-17204 [Android][CI] Fix PR-verify: changeset from merge parents + publishChecks reporting

### DIFF
--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -77,16 +77,31 @@ EOF
                         '''
                     }
 
-                    // Make the base branch available for the diff without fetching every branch.
-                    sh "git fetch --no-tags --force origin ${cfg.baseBranch}:refs/remotes/origin/${cfg.baseBranch}"
-
                     script {
-                        // Kotlin files changed on this PR vs the merge-base with the base branch.
-                        // Mirrors CircleCI's resolve_changeset (diff-filter=dr drops deletes/renames).
-                        env.KOTLIN_CHANGESET = sh(
-                            returnStdout: true,
-                            script: "git diff --name-only --diff-filter=dr --relative origin/${cfg.baseBranch}...HEAD | grep '\\.kt[s\"]\\?\$' || true"
-                        ).trim()
+                        // Resolve the Kotlin changeset WITHOUT a network fetch — a raw `git fetch`
+                        // in an sh step has no credentials (GIT_ASKPASS is scoped to `checkout scm`).
+                        //
+                        // With PR "merge" discovery, Jenkins checks out a merge commit whose first
+                        // parent is the target-branch tip and second parent is the PR head, so we
+                        // diff those two parents directly. Mirrors CircleCI's resolve_changeset
+                        // (diff-filter=dr drops deletes/renames).
+                        def parents = sh(returnStdout: true, script: 'git rev-list --parents -n 1 HEAD').trim().tokenize(' ')
+                        if (env.CHANGE_ID?.trim() && parents.size() >= 3) {
+                            String target = parents[1]
+                            String prHead = parents[2]
+                            echo "PR #${env.CHANGE_ID}: diffing target ${target} vs PR head ${prHead}"
+                            env.KOTLIN_CHANGESET = sh(
+                                returnStdout: true,
+                                script: "git diff --name-only --diff-filter=dr ${target} ${prHead} | grep '\\.kt[s\"]\\?\$' || true"
+                            ).trim()
+                        } else {
+                            // Not a PR merge build (e.g. a branch build). This job should discover
+                            // PRs only; skip the changeset linters rather than fail, and warn loudly.
+                            echo "WARNING: not a PR merge build (CHANGE_ID='${env.CHANGE_ID}'). " +
+                                 "Configure the Multibranch source for 'Discover pull requests' with the " +
+                                 "merge strategy and remove 'Discover branches'. Skipping ktlint/detekt changeset."
+                            env.KOTLIN_CHANGESET = ''
+                        }
                         echo "Kotlin changeset:\n${env.KOTLIN_CHANGESET ?: '(none)'}"
                     }
                 }

--- a/vars/githubStatusWrap.groovy
+++ b/vars/githubStatusWrap.groovy
@@ -1,18 +1,35 @@
 #!/usr/bin/env groovy
 
 /**
- * Runs `body` while reporting a single GitHub commit status under `context`
- * (e.g. "ci/jenkins: ktlint"): PENDING before, SUCCESS on clean exit, FAILURE
- * on throw. Repo + commit SHA are inferred from the checked-out SCM by the
- * GitHub plugin's githubNotify step.
+ * Runs `body` while reporting a GitHub check named `checkName`
+ * (e.g. "ci/jenkins: ktlint"): IN_PROGRESS before, COMPLETED/SUCCESS on clean
+ * exit, COMPLETED/FAILURE on throw.
+ *
+ * Uses the GitHub Checks plugin's `publishChecks` step. Publishing is best-effort:
+ * if it can't post (plugin/credentials not set up for the Checks API — e.g. a PAT
+ * instead of a GitHub App), it logs a warning rather than failing the build, so the
+ * check's real pass/fail is never masked by a reporting problem. The body's own
+ * failure always propagates.
  */
-def call(String context, Closure body) {
-    githubNotify context: context, status: 'PENDING', description: 'Running'
+def call(String checkName, Closure body) {
+    publish(checkName, 'IN_PROGRESS', null)
     try {
         body()
-        githubNotify context: context, status: 'SUCCESS', description: 'Passed'
+        publish(checkName, 'COMPLETED', 'SUCCESS')
     } catch (err) {
-        githubNotify context: context, status: 'FAILURE', description: 'Failed'
+        publish(checkName, 'COMPLETED', 'FAILURE')
         throw err
+    }
+}
+
+private void publish(String checkName, String status, String conclusion) {
+    try {
+        if (conclusion) {
+            publishChecks name: checkName, status: status, conclusion: conclusion
+        } else {
+            publishChecks name: checkName, status: status
+        }
+    } catch (Throwable t) {
+        echo "Check '${checkName}' (${status}${conclusion ? '/' + conclusion : ''}) not published: ${t.message}"
     }
 }


### PR DESCRIPTION
**Ticket:** [OP-17204](https://endios.atlassian.net/browse/OP-17204 "Link to JIRA")

**Purpose of this Pull Request:**

Two fixes to `androidPRVerify`, both found and verified against the first live runs of PR [endiosOneApp#2585](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2585):

**1. Changeset resolution without an unauthenticated fetch.** The original `git fetch origin develop` in an `sh` step had no credentials (Jenkins' `GIT_ASKPASS` is scoped to `checkout scm`) and aborted the build on our private repo with `could not read Username`. Now the changeset is diffed from the **PR merge commit's parents** (target tip = parent 1, PR head = parent 2) — no fetch, no credentials. Non-PR builds warn and skip the changeset linters instead of crashing.

**2. Status reporting via `publishChecks`.** `githubNotify` is not available on our Jenkins (`NoSuchMethodError` aborted the build). Switched to the GitHub Checks plugin's `publishChecks` (which is installed) and made publishing **best-effort** — a reporting failure logs a warning instead of failing the build (the old `catch` missed it because `NoSuchMethodError` is an `Error`, not an `Exception`). The check body's real pass/fail still propagates.

**Verified:** with `endiosOneApp@feature/OP-17204` overriding `@Library('android-ci@feature/OP-17204-ci-changeset-fix')`, PR-2585 discovered correctly, changeset resolved (`(none)` — no `.kt` changes), all stages ran, and `continuous-integration/jenkins/pr-merge` went **green**.

**Additional Note:** per-stage `ci/jenkins:` checks only render if the branch source uses a GitHub App credential (Checks API); with the current PAT they log "not published" and the overall `pr-merge` status is the gate. GitHub App is a possible follow-up.

**Deprecations (if any):** None.

[OP-17204]: https://endios.atlassian.net/browse/OP-17204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ