### PR TITLE
OP-17235 [Android][Config] Bump version.foundation to 5.5.45

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.44"
+version.foundation = "5.5.45"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) from 5.5.44 → 5.5.45 to pick up the OP-17235 Lottie-tile accessibility fix.
- `version.foundation_release` (STABLE) is untouched.

## Merge order
1. endiosOneFoundation-Android [#910](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/910) — the fix; must merge & publish `foundation` 5.5.45 first.
2. **This PR** — bump the catalog only after 5.5.45 is on Maven, else every downstream build breaks in the gap.

## Test plan
- CI resolves `de.endios.one.core:foundation:5.5.45` after the artifact publishes.
🤖 Generated with [Claude Code](https://claude.com/claude-code)