### PR TITLE
OP-16478 [Android][Config] Bump version.foundation to 5.5.47

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.46"
+version.foundation = "5.5.47"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` → 5.5.47 to pick up the OP-16478 fix: the notification **Open** event now fires for notifications tapped from the background (SDK-displayed), not just foreground ones. (Re-bumped from 5.5.46 after develop shipped OP-17235 as 5.5.46, which claimed 5.5.46.)

## Merge order
1. [Android-Config #802](https://github.com/endiosGmbH/Android-Config/pull/802) (OP-17309, @nicolaiendios) — adds `dependency.test.robolectric` to the catalog (merges first; Foundation #911's tests need it). Supersedes our #800, which will be closed.
2. [endiosOneFoundation-Android #911](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/911) — publishes Foundation 5.5.47 (merge after #802, wait for publish).
3. **This PR** — `version.foundation = 5.5.47` (merge only after 5.5.47 is published).

## Test plan
CI dependency resolution against the published 5.5.47 artifact.
