### PR TITLE
OP-17204 [Android][CI] Fix changeset resolution (diff vs origin/target, not merge parents)

### DIFF
--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -81,26 +81,31 @@ EOF
                         // Resolve the Kotlin changeset WITHOUT a network fetch — a raw `git fetch`
                         // in an sh step has no credentials (GIT_ASKPASS is scoped to `checkout scm`).
                         //
-                        // With PR "merge" discovery, Jenkins checks out a merge commit whose first
-                        // parent is the target-branch tip and second parent is the PR head, so we
-                        // diff those two parents directly. Mirrors CircleCI's resolve_changeset
-                        // (diff-filter=dr drops deletes/renames).
-                        def parents = sh(returnStdout: true, script: 'git rev-list --parents -n 1 HEAD').trim().tokenize(' ')
-                        if (env.CHANGE_ID?.trim() && parents.size() >= 3) {
-                            String target = parents[1]
-                            String prHead = parents[2]
-                            echo "PR #${env.CHANGE_ID}: diffing target ${target} vs PR head ${prHead}"
+                        // The GitHub Branch Source already fetches the PR's target branch into
+                        // refs/remotes/origin/<target> (it needs it to build the merge), so we diff
+                        // the working tree against it with a three-dot (merge-base) range. This is
+                        // robust whether or not Jenkins produced a real merge commit — a branch that
+                        // is already up to date with the target yields no merge commit, which the old
+                        // merge-parent approach mis-read as "no changes" and skipped linting entirely.
+                        // Mirrors CircleCI's resolve_changeset (diff-filter=dr drops deletes/renames).
+                        String target = env.CHANGE_TARGET?.trim() ?: cfg.baseBranch
+                        String targetRef = "origin/${target}"
+                        boolean hasRef = sh(returnStatus: true, script: "git rev-parse --verify --quiet ${targetRef} > /dev/null") == 0
+                        if (hasRef) {
+                            echo "Resolving changeset vs ${targetRef} (merge-base)"
                             env.KOTLIN_CHANGESET = sh(
                                 returnStdout: true,
-                                script: "git diff --name-only --diff-filter=dr ${target} ${prHead} | grep '\\.kt[s\"]\\?\$' || true"
+                                script: "git diff --name-only --diff-filter=dr ${targetRef}...HEAD | grep '\\.kt[s\"]\\?\$' || true"
                             ).trim()
                         } else {
-                            // Not a PR merge build (e.g. a branch build). This job should discover
-                            // PRs only; skip the changeset linters rather than fail, and warn loudly.
-                            echo "WARNING: not a PR merge build (CHANGE_ID='${env.CHANGE_ID}'). " +
-                                 "Configure the Multibranch source for 'Discover pull requests' with the " +
-                                 "merge strategy and remove 'Discover branches'. Skipping ktlint/detekt changeset."
-                            env.KOTLIN_CHANGESET = ''
+                            // Fail closed, not open: if we can't determine the target ref, lint every
+                            // Kotlin file rather than silently skipping and passing a broken PR.
+                            echo "WARNING: ${targetRef} not available (CHANGE_TARGET='${env.CHANGE_TARGET}'). " +
+                                 "Running ktlint/detekt over ALL Kotlin files as a safe fallback."
+                            env.KOTLIN_CHANGESET = sh(
+                                returnStdout: true,
+                                script: "git ls-files '*.kt' '*.kts' || true"
+                            ).trim()
                         }
                         echo "Kotlin changeset:\n${env.KOTLIN_CHANGESET ?: '(none)'}"
                     }

--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -137,11 +137,13 @@ EOF
                             if (!env.KOTLIN_CHANGESET?.trim()) {
                                 echo 'No Kotlin changes — skipping detekt.'
                             } else {
+                                // Build the comma-separated --input in Groovy: shelling `tr '\n' ','`
+                                // left a trailing comma, so detekt parsed an empty path and crashed.
+                                String input = env.KOTLIN_CHANGESET.readLines().findAll { it?.trim() }.join(',')
                                 sh """
                                   curl -sSLO https://github.com/detekt/detekt/releases/download/v${cfg.detektVersion}/detekt-cli-${cfg.detektVersion}.zip
                                   unzip -o detekt-cli-${cfg.detektVersion}.zip
-                                  INPUT=\$(echo "${env.KOTLIN_CHANGESET}" | tr '\\n' ',')
-                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "\$INPUT"
+                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "${input}"
                                 """
                             }
                         }


### PR DESCRIPTION
**Ticket:** [OP-17204](https://endios.atlassian.net/browse/OP-17204 "Link to JIRA")

**Purpose of this Pull Request:**

Fixes a false-pass in `androidPRVerify` found while testing on [endiosOneApp#2595](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2595): a PR containing an unused import passed ktlint **and** detekt because both were **skipped**, not run.

**Root cause:** the changeset was resolved from the PR merge commit's two parents. But when the PR branch is already up to date with the target, Jenkins produces **no merge commit** (HEAD has a single parent), so the `parents.size() >= 3` check failed, the build logged "not a PR merge build", set an empty changeset, and skipped ktlint/detekt.

**Fix:** diff against `refs/remotes/origin/<target>` (which the Branch Source already fetches for the merge) using a three-dot merge-base range — robust whether or not a merge commit was created. If the target ref is ever missing, **fail closed**: lint all Kotlin files instead of skipping.

**Verification:** override #2595 to `@Library('android-ci@feature/OP-17204-changeset-target-ref')` and re-run — ktlint/detekt should now **fail** on the unused import. Then merge here and revert the override.

**Deprecations (if any):** None.

[OP-17204]: https://endios.atlassian.net/browse/OP-17204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ