### PR TITLE
OP-17204 [Android][CI] Make detekt --plugins optional in androidPRVerify

### DIFF
--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -140,10 +140,13 @@ EOF
                                 // Build the comma-separated --input in Groovy: shelling `tr '\n' ','`
                                 // left a trailing comma, so detekt parsed an empty path and crashed.
                                 String input = env.KOTLIN_CHANGESET.readLines().findAll { it?.trim() }.join(',')
+                                // --plugins is optional: some repos (e.g. oneDataProvider) run detekt
+                                // without the formatting plugin. Omit the flag when detektPlugin is blank.
+                                String pluginArg = cfg.detektPlugin ? "--plugins ${cfg.detektPlugin}" : ''
                                 sh """
                                   curl -sSLO https://github.com/detekt/detekt/releases/download/v${cfg.detektVersion}/detekt-cli-${cfg.detektVersion}.zip
                                   unzip -o detekt-cli-${cfg.detektVersion}.zip
-                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "${input}"
+                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} ${pluginArg} --input "${input}"
                                 """
                             }
                         }


### PR DESCRIPTION
**Ticket:** [OP-17204](https://endios.atlassian.net/browse/OP-17204)

Prep for the fleet rollout (Foundation batch). `oneDataProvider` and likely some widgets run detekt without the formatting plugin (`--config` only, no `--plugins`). Make `detektPlugin` optional — when blank, the `--plugins` flag is omitted — so those repos pass `detektPlugin: ''` instead of crashing on a missing jar. No change for repos that keep the default plugin path.

Docs-adjacent to #796. Verified logic; behavior unchanged for existing consumers.

[OP-17204]: https://endios.atlassian.net/browse/OP-17204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ