### PR TITLE
OP-16478 [Android][Config] Add Robolectric to the test dependency catalog

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -73,6 +73,7 @@ version.junit_jupiter = "5.11.0"
 version.junit_jupiter_plugin = "1.8.2.1"
 version.junit_platform_launcher = "1.13.4"
 version.junit_ktx = "1.1.5"
+version.robolectric = "4.16"
 //test
 version.core_ktx = "1.5.0"
 // kohii
@@ -297,6 +298,7 @@ test.jupiter_plugin = "de.mannodermaus.gradle.plugins:android-junit5:$version.ju
 test.junit_platform_launcher = "org.junit.platform:junit-platform-launcher:$version.junit_platform_launcher"
 test.core_ktx = "androidx.test:core-ktx:$version.core_ktx"
 test.junit_ktx = "androidx.test.ext:junit-ktx:$version.junit_ktx"
+test.robolectric = "org.robolectric:robolectric:$version.robolectric"
 dependency.test = test
 
 def ui_test = [:]


### PR DESCRIPTION
## Summary
- Adds `dependency.test.robolectric` (`org.robolectric:robolectric:4.16`) to the shared catalog.
- Needed by endiosOneFoundation-Android #911 (OP-16478): the new `NotificationOpenDetailsTest` runs under Robolectric with a real `Bundle` so the `RemoteMessage` reconstruction and `getData()` `google.`/`gcm.` key-stripping are exercised for real (per review feedback — mocking those wholesale would let a wrong FCM key pass green).
- `4.16` matches endiosOneApp, the only current Robolectric consumer.

## Merge order
1. **This PR** — adds `test.robolectric` to the catalog. Merges to `develop` **first**: repos pull the catalog from `Android-Config/develop` at build time, so Foundation #911's tests won't compile until this lands.
2. [endiosOneFoundation-Android #911](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/911) — consumes `dependency.test.robolectric`; publishes Foundation 5.5.46.
3. [Android-Config #794](https://github.com/endiosGmbH/Android-Config/pull/794) — `version.foundation = 5.5.46` (merge only after 5.5.46 is published).

## Test plan
Catalog-only change; consumed and green-verified by Foundation #911's `:platform-main:testDebugUnitTest`.