### PR TITLE
OP-17235 [Android] Bump version.foundation to 5.5.46

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.45"
+version.foundation = "5.5.46"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## What & why

Bump `version.foundation` 5.5.45 → 5.5.46 so consumers pick up the OP-17235 touch-explore fix for the shared Lottie tile.

Foundation 5.5.46 makes the Lottie tile reachable by TalkBack **touch-explore** (dragging a finger over it), not just by swipe — matching sibling tiles. Follow-up to the 5.5.45 single-stop fix.

## Merge order

1. [endiosOneFoundation-Android#914](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/914) — Foundation fix; publishes `foundation` 5.5.46 on merge to develop.
2. **This PR** — bump `version.foundation` → 5.5.46. Merge only **after** 5.5.46 has published, or every downstream build breaks in the gap.
