### PR TITLE
OP-17309 [Android][Config] Add Robolectric to the dependency catalog

### DIFF
--- a/.ai/specs/OP-17309.md
+++ b/.ai/specs/OP-17309.md
@@ -1,0 +1,72 @@
+# Spec: Add Robolectric to the Android-Config dependency catalog
+
+**Ticket:** [OP-17309](https://endios.atlassian.net/browse/OP-17309)
+**Created:** 2026-07-11
+**Status:** Implemented
+
+## Context
+
+Robolectric is already used for unit tests in several widgets, where the dependency
+coordinate is **hardcoded** in each widget's `build.gradle`:
+
+- `oneWidgetContent-Android` → `org.robolectric:robolectric:4.16`
+- `oneWidgetWebview-Android` → `org.robolectric:robolectric:4.16`
+- `oneWidgetNews-Android` → `org.robolectric:robolectric:4.12.2` (older)
+
+We now want to use Robolectric in Foundation (`endiosOneFoundation-Android`) too. To
+avoid version drift and duplicated coordinates, Robolectric should be declared once in
+the central Android-Config dependency catalog (`version.gradle`), exactly like
+`junit`, `mockk`, etc., so every module can consume it via `dependency.test.robolectric`.
+
+## Requirements
+
+### Functional
+- Add a `version.robolectric` entry to the version block of `version.gradle`, set to `4.16`
+  (the latest version already in use).
+- Add `test.robolectric = "org.robolectric:robolectric:$version.robolectric"` to the
+  existing `dependency.test` group (`def test = [:]`), so consumers reference
+  `dependency.test.robolectric`.
+
+### Non-Functional
+- No hardcoded version inside the coordinate string — the coordinate interpolates
+  `$version.robolectric` (consistent with every other entry in the catalog).
+- Placement follows the file's existing conventions (roughly alphabetical version block;
+  entry added to the `test` dependency map next to `test.base` / `test.junit_ktx`).
+
+## Behaviors (verification plan)
+
+This is a Gradle dependency-catalog change — there is no unit-testable production code, so
+each behavior below is verified by Gradle resolution rather than a red-green-refactor test.
+
+1. [x] Given the version block, when Robolectric's version is looked up, then `version.robolectric == "4.16"` is defined exactly once.
+2. [x] Given the `dependency.test` group, when a consumer references `dependency.test.robolectric`, then it resolves to the coordinate `org.robolectric:robolectric:4.16`.
+3. [x] Given the coordinate string, when inspected, then it interpolates `$version.robolectric` and contains no literal version number.
+4. [x] Given a consumer `build.gradle` (Foundation or a widget), when it declares `testImplementation dependency.test.robolectric`, then Gradle resolves the artifact without error.
+
+## Technical Notes
+
+- **Affected files/modules:** `Android-Config/version.gradle` (version block ~line 91–92; `def test` map ~line 284–293).
+- **Stack considerations:** Groovy Gradle script; the catalog is an `ext`-scoped `dependency` map imported by every Android repo.
+- **Architecture constraints:** Match the existing `test.*` entries; do not introduce a `libs.versions.toml` (this repo uses the legacy `version.gradle` map).
+- **Dependencies:** `org.robolectric:robolectric:4.16` (Maven Central).
+
+## Affected repositories
+
+**Primary change (this ticket):**
+- **Android-Config** — add `version.robolectric` + `dependency.test.robolectric` to `version.gradle`.
+
+**Repos that adopt the new catalog entry (follow-up / driving need — NOT in this ticket):**
+- **endiosOneFoundation-Android** — the reason for centralizing; will add `testImplementation dependency.test.robolectric` to the module(s) that need it.
+- **oneWidgetContent-Android** — replace hardcoded `4.16` with `dependency.test.robolectric`.
+- **oneWidgetWebview-Android** — replace hardcoded `4.16` with `dependency.test.robolectric`.
+- **oneWidgetNews-Android** — replace hardcoded `4.12.2` with `dependency.test.robolectric` (upgrades to 4.16).
+
+## Open Questions
+
+- None. Scope confirmed as catalog-only, version 4.16.
+
+## QA
+
+**Recommended app:** _not applicable — build-configuration change with no runtime surface._
+**Environment:** n/a
+**Reason:** This only adds a dependency coordinate to the shared catalog; verification is a Gradle resolution check, not an app QA pass.

--- a/version.gradle
+++ b/version.gradle
@@ -90,6 +90,8 @@ version.play_services_maps = "18.1.0"
 version.play_services_location = "21.0.0"
 // retrofit
 version.retrofit = "3.0.0"
+// robolectric
+version.robolectric = "4.16"
 // vertx-codegen
 version.vertx_codegen = "3.6.0"
 // jetpack-compose
@@ -297,6 +299,7 @@ test.jupiter_plugin = "de.mannodermaus.gradle.plugins:android-junit5:$version.ju
 test.junit_platform_launcher = "org.junit.platform:junit-platform-launcher:$version.junit_platform_launcher"
 test.core_ktx = "androidx.test:core-ktx:$version.core_ktx"
 test.junit_ktx = "androidx.test.ext:junit-ktx:$version.junit_ktx"
+test.robolectric = "org.robolectric:robolectric:$version.robolectric"
 dependency.test = test
 
 def ui_test = [:]


### PR DESCRIPTION
**Ticket:** [OP-17309](https://endios.atlassian.net/browse/OP-17309 "Link to JIRA")

**Purpose of this Pull Request:**

Declares Robolectric once in the central dependency catalog (`version.gradle`) so Foundation (`endiosOneFoundation-Android`) and widgets can consume it via `dependency.test.robolectric` instead of hardcoding the coordinate in each `build.gradle`.

- Adds `version.robolectric = "4.16"` to the version block.
- Adds `test.robolectric = "org.robolectric:robolectric:$version.robolectric"` to the existing `dependency.test` group.

Standardizes on **4.16** — the latest version already in use (oneWidgetContent, oneWidgetWebview). oneWidgetNews still pins an older 4.12.2.

**Additional Note:**

Verified end-to-end: pointed oneWidgetContent at this branch's `version.gradle`, swapped its hardcoded line for `dependency.test.robolectric`, and `dependencyInsight` resolved it to `org.robolectric:robolectric:4.16`.

Adoption in Foundation and migration of the hardcoded widget declarations (Content/Webview/News) are follow-ups tracked in the ticket — not included here.

**Deprecations (if any):**

None.

[OP-17309]: https://endios.atlassian.net/browse/OP-17309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ