### PR TITLE
OP-17309 [Android][Config] Add Robolectric to the dependency catalog (master)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -90,6 +90,8 @@ version.play_services_maps = "18.1.0"
 version.play_services_location = "21.0.0"
 // retrofit
 version.retrofit = "2.6.1"
+// robolectric
+version.robolectric = "4.16"
 // vertx-codegen
 version.vertx_codegen = "3.6.0"
 // jetpack-compose
@@ -290,6 +292,7 @@ test.jupiter_plugin = "de.mannodermaus.gradle.plugins:android-junit5:$version.ju
 test.junit_platform_launcher = "org.junit.platform:junit-platform-launcher:$version.junit_platform_launcher"
 test.core_ktx = "androidx.test:core-ktx:$version.core_ktx"
 test.junit_ktx = "androidx.test.ext:junit-ktx:$version.junit_ktx"
+test.robolectric = "org.robolectric:robolectric:$version.robolectric"
 dependency.test = test
 
 def ui_test = [:]


### PR DESCRIPTION
**Ticket:** [OP-17309](https://endios.atlassian.net/browse/OP-17309 "Link to JIRA")

**Purpose of this Pull Request:**

Promotes the Robolectric catalog entry to `master`. Mirrors the `develop` change ([#802](https://github.com/endiosGmbH/Android-Config/pull/802), already merged):

- `version.robolectric = "4.16"`
- `test.robolectric = "org.robolectric:robolectric:$version.robolectric"`

**Additional Note:**

Widget **modules** resolve `dependency.*` from `master/version.gradle` (via `lib_ui_tests.gradle`), so the entry must exist on `master` before the widget adoption PRs can build/merge:

- oneWidgetContent#169
- oneWidgetNews#150

Fast-tracked directly to `master` (outside the usual `release/*` flow) because it's a trivial, additive, test-only catalog entry that unblocks those PRs. Identical to the merged `develop` version.

**Deprecations (if any):**

None.

[OP-17309]: https://endios.atlassian.net/browse/OP-17309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ