### PR TITLE
OP-17065 [Android][Config] Bump version.foundation to 5.5.48

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.46"
+version.foundation = "5.5.48"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) **5.5.46 → 5.5.47** for the OP-17065 deletion of `RoundImageView` / `RoundedImageView` / `OneViewComponentRoundedImageView`.
- `version.foundation_release` (STABLE) is untouched.

## Test plan
- Catalog-only change.

## Merge order
1. [Foundation #915](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/915) — deletes the classes; merge publishes Foundation 5.5.47.
2. **This PR** (Android-Config #804) — `version.foundation` → 5.5.47; merge **only after** 5.5.47 is on maven.

[Foundation-Check #23](https://github.com/endiosGmbH/endiosOneFoundation-Check-Android/pull/23) — drops the test's `RoundImageView` reference; backward-compatible, may merge any time (does not gate the others).
