### PR TITLE
OP-17208 [Android][Config] Bump version.foundation to 5.5.49

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.47"
+version.foundation = "5.5.49"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) `5.5.47` → `5.5.49` so consumers pick up the OP-17208 `DetailBox` / `DetailBoxStyle.showBackground` change once Foundation 5.5.49 is published.

## Merge order
The `DetailBox` / `DetailBoxStyle` change is **binary-incompatible** for published widgets, so the chain must land in order — and the app must not ship the new Foundation until all 5 widgets are rebuilt & bumped.

1. [endiosOneFoundation-Android#916](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/916) — Foundation OP-17208 (5.5.49); merge + publish first.
2. [Android-Config#805](https://github.com/endiosGmbH/Android-Config/pull/805) — `version.foundation` → 5.5.49; merge only after Foundation 5.5.49 is published. ← **this PR**
3. Widget republishes — rebuild against 5.5.49, bump each; independent of each other → **parallel**:
   - [oneWidgetParking#125](https://github.com/endiosGmbH/oneWidgetParking-Android/pull/125) — OP-17334
   - [oneWidgetBonusPoints#74](https://github.com/endiosGmbH/oneWidgetBonusPoints-Android/pull/74) — OP-17335
   - [oneWidgetCityGuide#104](https://github.com/endiosGmbH/oneWidgetCityGuide-Android/pull/104) — OP-17336
   - [oneWidgetECharging#131](https://github.com/endiosGmbH/oneWidgetECharging-Android/pull/131) — OP-17337
   - [oneWidgetOffers#372](https://github.com/endiosGmbH/oneWidgetOffers-Android/pull/372) — OP-17338
4. [endiosOneApp#2606](https://github.com/endiosGmbH/endiosOneApp-Android/pull/2606) — bump all 5 rebuilt widget deps; ships with Foundation 5.5.49 (via Android-Config). Merge last, after all 5 widgets are republished — the **release gate**.

> Note: Foundation 5.5.49 is also claimed by OP-17110 (#917); whichever Foundation PR merges first keeps it, the other re-bumps.
