### PR TITLE
OP-17110 [Android][Config] Bump version.foundation to 5.5.50

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.49"
+version.foundation = "5.5.50"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) → **5.5.50** to pick up the OP-17110 address-field white/invisible fix in Foundation's `AddressBottomSheetPicker`.
- `version.foundation_release` (STABLE) is untouched.

## Merge order
This must merge **after** Foundation publishes 5.5.50 on develop, or downstream builds break in the gap.
1. [endiosOneFoundation-Android #917](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/917) — Foundation fix, merges + publishes 5.5.50 first
2. **This PR** — points the catalog at 5.5.50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
