### PR TITLE
OP-17339 Curate release-candidate: tested Foundation versions + CI shared library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Android-Config
 Configuration for android projects. No keys or business logic.
+
+Also hosts the **`android-ci`** Jenkins shared pipeline library (`vars/`). See [docs/android-ci.md](docs/android-ci.md).

--- a/docs/android-ci.md
+++ b/docs/android-ci.md
@@ -12,7 +12,7 @@ Android-Config (gradle scripts, `version.gradle`, `tooling/`) is ignored by the 
 ```
 vars/
   androidPRVerify.groovy   # PR-verify pipeline (ktlint, detekt, lint, unit tests)
-  githubStatusWrap.groovy  # per-check GitHub commit-status wrapper
+  githubStatusWrap.groovy  # per-check reporter via publishChecks (best-effort)
 ```
 
 ## Consuming it
@@ -34,15 +34,50 @@ androidPRVerify(lintTask: 'lint', unitTestTask: 'testDebugUnitTest')
 
 1. **Register the library** — *Manage Jenkins → System → Global Pipeline Libraries*:
    name `android-ci`, default version `develop` (Android-Config's trunk), SCM = this repo.
-2. **Create a Multibranch Pipeline** job per consuming repo pointed at `Jenkinsfile.prverify`,
-   discovering **Pull Requests only** (not branches) to avoid duplicate builds.
-3. **Webhook:** point the consuming repo's GitHub webhook at
-   `https://bouncer.jenkins.endios.one/github-webhook` and set the shared secret.
-   Jenkins validates the HMAC — the bouncer does not.
-4. **Suppress the native status:** enable the *skip-notifications-trait* on the job so only
-   the `ci/jenkins: *` statuses show (not `continuous-integration/jenkins/pr-head`).
-5. **Branch protection:** once green, mark `ci/jenkins: ktlint|detekt|lint|tests` as required
-   and remove the CircleCI checks.
+   Tick *Allow default version to be overridden* so a repo can test a fix branch via
+   `@Library('android-ci@some-branch')` before it merges.
+2. **Shared webhook secret** — *Manage Jenkins → System → GitHub → Advanced → Shared secret*
+   (a *Secret text* credential). Jenkins validates the webhook HMAC with it; the bouncer does not.
+
+## Per-repo cutover checklist
+
+For each repo (endiosOneApp done; widgets + Foundation to follow):
+
+1. **Add `Jenkinsfile.prverify`** — thin wrapper: `@Library('android-ci') _` + `androidPRVerify(...)`
+   (override `lintTask`/`unitTestTask` if the repo has different flavors).
+2. **Delete `.circleci/config.yml`** — immediate cutover; a repo runs on exactly one CI.
+3. **Create a Multibranch Pipeline job** pointed at `Jenkinsfile.prverify`. Branch-source
+   **Behaviors — exactly one:**
+   - ✅ *Discover pull requests from origin* → **"Merging the pull request with the current target branch revision"**
+   - ❌ **No** *Discover branches* (builds every branch push → duplicate/irrelevant builds)
+   - ❌ **No** *Discover pull requests from forks* (we take no external forks; its "head" strategy adds a `pr-head` status)
+   - This yields a single status context: **`continuous-integration/jenkins/pr-merge`**.
+4. **Webhook** — repo → Settings → Webhooks: URL `https://bouncer.jenkins.endios.one/github-webhook/`,
+   content type `application/json`, secret = the shared secret above, events **Pushes + Pull requests** only.
+5. **Branch protection** (target branch, usually `develop`): remove the `ci/circleci: *` required
+   checks, add **`continuous-integration/jenkins/pr-merge`** as required. Keep *Require branches up to date*.
+
+## Gotchas learned in the pilot (OP-17204)
+
+- **Only the PR-verify job may discover PRs.** One webhook fans out to *every* Jenkins job whose
+  branch source watches the repo. The `endiosOneApp-Android-Maestro` job discovered PRs and ran a
+  full UI-test build on a PR-verify PR. Any other job on the repo (release, uitests, maestro) must
+  **not** discover PRs. Nightly/manual jobs: keep branch discovery but add **"Suppress automatic
+  SCM triggering"** so pushes don't auto-build (cron + manual still work).
+- **Use the merge strategy, and diff against `origin/<target>`** — not the merge commit's parents.
+  When a PR branch is already up to date with the target, Jenkins produces **no merge commit**, so a
+  parent-based changeset resolves to empty and ktlint/detekt silently **skip** (a bad PR passes).
+  `androidPRVerify` diffs `origin/${CHANGE_TARGET}...HEAD` (the branch source already fetches the
+  target); if that ref is missing it fails closed by linting all Kotlin files.
+- **Don't fetch inside an `sh` step.** `GIT_ASKPASS` credentials are scoped to `checkout scm`; a raw
+  `git fetch` has none and dies with `could not read Username` on private repos. The target ref is
+  already fetched — just diff against it.
+- **`githubNotify` is not installed here; `publishChecks` is.** Status reporting uses `publishChecks`
+  and is best-effort (a publish failure logs a warning, never fails the build).
+- **Inline per-stage errors need a GitHub App.** With the current **PAT** branch-source credential,
+  `publishChecks` logs `No suitable checks publisher found` — only the overall `pr-merge` status
+  shows on the PR (details are in the Jenkins console). To render `ci/jenkins: *` checks and
+  line-level annotations on the PR, the branch source must authenticate as a **GitHub App**.
 
 ## ⚠️ When Android-Config goes private
 

--- a/docs/android-ci.md
+++ b/docs/android-ci.md
@@ -1,0 +1,53 @@
+# android-ci — Jenkins shared library
+
+Shared pipeline steps for endios Android CI, hosted in this repo and registered in
+Jenkins under the logical name **`android-ci`**. Analogous to the iOS `ios-ci` library
+(OP-17160). First consumer: `endiosOneApp-Android` PR-verify (OP-17204).
+
+Jenkins reads `vars/`, `src/`, and `resources/` from the repo root; the rest of
+Android-Config (gradle scripts, `version.gradle`, `tooling/`) is ignored by the library.
+
+## Contents
+
+```
+vars/
+  androidPRVerify.groovy   # PR-verify pipeline (ktlint, detekt, lint, unit tests)
+  githubStatusWrap.groovy  # per-check GitHub commit-status wrapper
+```
+
+## Consuming it
+
+Repo `Jenkinsfile.prverify`:
+
+```groovy
+@Library('android-ci') _
+androidPRVerify()
+```
+
+Per-repo overrides (widgets/Foundation with different flavors):
+
+```groovy
+androidPRVerify(lintTask: 'lint', unitTestTask: 'testDebugUnitTest')
+```
+
+## Jenkins setup (one-time, infra)
+
+1. **Register the library** — *Manage Jenkins → System → Global Pipeline Libraries*:
+   name `android-ci`, default version `develop` (Android-Config's trunk), SCM = this repo.
+2. **Create a Multibranch Pipeline** job per consuming repo pointed at `Jenkinsfile.prverify`,
+   discovering **Pull Requests only** (not branches) to avoid duplicate builds.
+3. **Webhook:** point the consuming repo's GitHub webhook at
+   `https://bouncer.jenkins.endios.one/github-webhook` and set the shared secret.
+   Jenkins validates the HMAC — the bouncer does not.
+4. **Suppress the native status:** enable the *skip-notifications-trait* on the job so only
+   the `ci/jenkins: *` statuses show (not `continuous-integration/jenkins/pr-head`).
+5. **Branch protection:** once green, mark `ci/jenkins: ktlint|detekt|lint|tests` as required
+   and remove the CircleCI checks.
+
+## ⚠️ When Android-Config goes private
+
+This library is loaded from Android-Config over SCM. Once the repo is private, Jenkins can no
+longer fetch it anonymously — the Global Pipeline Library config **must** be given SCM checkout
+credentials (a machine user / deploy key / PAT with read access). Without them, every consuming
+job fails at library resolution before any stage runs. Update the library's *Source Code
+Management → Credentials* at the same time the repo visibility changes.

--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -81,26 +81,31 @@ EOF
                         // Resolve the Kotlin changeset WITHOUT a network fetch — a raw `git fetch`
                         // in an sh step has no credentials (GIT_ASKPASS is scoped to `checkout scm`).
                         //
-                        // With PR "merge" discovery, Jenkins checks out a merge commit whose first
-                        // parent is the target-branch tip and second parent is the PR head, so we
-                        // diff those two parents directly. Mirrors CircleCI's resolve_changeset
-                        // (diff-filter=dr drops deletes/renames).
-                        def parents = sh(returnStdout: true, script: 'git rev-list --parents -n 1 HEAD').trim().tokenize(' ')
-                        if (env.CHANGE_ID?.trim() && parents.size() >= 3) {
-                            String target = parents[1]
-                            String prHead = parents[2]
-                            echo "PR #${env.CHANGE_ID}: diffing target ${target} vs PR head ${prHead}"
+                        // The GitHub Branch Source already fetches the PR's target branch into
+                        // refs/remotes/origin/<target> (it needs it to build the merge), so we diff
+                        // the working tree against it with a three-dot (merge-base) range. This is
+                        // robust whether or not Jenkins produced a real merge commit — a branch that
+                        // is already up to date with the target yields no merge commit, which the old
+                        // merge-parent approach mis-read as "no changes" and skipped linting entirely.
+                        // Mirrors CircleCI's resolve_changeset (diff-filter=dr drops deletes/renames).
+                        String target = env.CHANGE_TARGET?.trim() ?: cfg.baseBranch
+                        String targetRef = "origin/${target}"
+                        boolean hasRef = sh(returnStatus: true, script: "git rev-parse --verify --quiet ${targetRef} > /dev/null") == 0
+                        if (hasRef) {
+                            echo "Resolving changeset vs ${targetRef} (merge-base)"
                             env.KOTLIN_CHANGESET = sh(
                                 returnStdout: true,
-                                script: "git diff --name-only --diff-filter=dr ${target} ${prHead} | grep '\\.kt[s\"]\\?\$' || true"
+                                script: "git diff --name-only --diff-filter=dr ${targetRef}...HEAD | grep '\\.kt[s\"]\\?\$' || true"
                             ).trim()
                         } else {
-                            // Not a PR merge build (e.g. a branch build). This job should discover
-                            // PRs only; skip the changeset linters rather than fail, and warn loudly.
-                            echo "WARNING: not a PR merge build (CHANGE_ID='${env.CHANGE_ID}'). " +
-                                 "Configure the Multibranch source for 'Discover pull requests' with the " +
-                                 "merge strategy and remove 'Discover branches'. Skipping ktlint/detekt changeset."
-                            env.KOTLIN_CHANGESET = ''
+                            // Fail closed, not open: if we can't determine the target ref, lint every
+                            // Kotlin file rather than silently skipping and passing a broken PR.
+                            echo "WARNING: ${targetRef} not available (CHANGE_TARGET='${env.CHANGE_TARGET}'). " +
+                                 "Running ktlint/detekt over ALL Kotlin files as a safe fallback."
+                            env.KOTLIN_CHANGESET = sh(
+                                returnStdout: true,
+                                script: "git ls-files '*.kt' '*.kts' || true"
+                            ).trim()
                         }
                         echo "Kotlin changeset:\n${env.KOTLIN_CHANGESET ?: '(none)'}"
                     }

--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -1,0 +1,155 @@
+#!/usr/bin/env groovy
+
+/**
+ * Shared PR-verify pipeline for endios Android repos.
+ *
+ * Replaces the CircleCI `*_pr_verify` workflow: ktlint + detekt on the Kotlin
+ * changeset (vs the PR base branch), Android lint, and unit tests. Each check
+ * reports an independent `ci/jenkins: <check>` GitHub commit status.
+ *
+ * Usage — repo `Jenkinsfile.prverify`:
+ *
+ *   @Library('android-ci') _
+ *   androidPRVerify()
+ *
+ * Overridable config (defaults match endiosOneApp-Android):
+ *
+ *   androidPRVerify(
+ *     baseBranch   : 'develop',
+ *     ktlintVersion: '0.40.0',
+ *     detektVersion: '1.22.0',
+ *     detektConfig : 'tooling/.detekt/detekt-config.yml',
+ *     detektPlugin : 'tooling/.detekt/detekt-formatting-1.22.0.jar',
+ *     lintTask     : 'lintDevelopDebug',
+ *     unitTestTask : 'testDevelopDebugUnitTest',
+ *     agentLabel   : 'android',
+ *   )
+ *
+ * Note: suppressing the native `continuous-integration/jenkins/pr-head` status
+ * is a job-level trait (skip-notifications-trait plugin), configured on the
+ * Multibranch job — not here. HMAC webhook-secret validation is Jenkins-side too;
+ * the bouncer (bouncer.jenkins.endios.one) does not validate payloads.
+ */
+def call(Map config = [:]) {
+    Map cfg = [
+        baseBranch   : 'develop',
+        ktlintVersion: '0.40.0',
+        detektVersion: '1.22.0',
+        detektConfig : 'tooling/.detekt/detekt-config.yml',
+        detektPlugin : 'tooling/.detekt/detekt-formatting-1.22.0.jar',
+        lintTask     : 'lintDevelopDebug',
+        unitTestTask : 'testDevelopDebugUnitTest',
+        agentLabel   : 'android',
+    ] + config
+
+    pipeline {
+        agent { label cfg.agentLabel }
+
+        options {
+            skipDefaultCheckout()
+            disableConcurrentBuilds()
+            timeout(time: 45, unit: 'MINUTES')
+            buildDiscarder(logRotator(numToKeepStr: '30', daysToKeepStr: '30'))
+        }
+
+        environment {
+            ANDROID_HOME     = '/Users/endiosworker/Library/Android/sdk'
+            ANDROID_SDK_ROOT = '/Users/endiosworker/Library/Android/sdk'
+            JAVA_HOME        = '/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home'
+            PATH             = "${JAVA_HOME}/bin:/opt/homebrew/bin:${env.PATH}"
+        }
+
+        stages {
+            stage('Checkout & Changeset') {
+                steps {
+                    // skipDefaultCheckout() is on, so check out explicitly (once).
+                    checkout scm
+
+                    withCredentials([
+                        string(credentialsId: 'MAVEN_USER', variable: 'MAVEN_USER'),
+                        string(credentialsId: 'MAVEN_PASS', variable: 'MAVEN_PASS'),
+                    ]) {
+                        sh '''
+                          cat > local.properties << EOF
+ENDIOS_DE_HTACCESS_USER=${MAVEN_USER}
+ENDIOS_DE_HTACCESS_PASSWORD=${MAVEN_PASS}
+EOF
+                        '''
+                    }
+
+                    // Make the base branch available for the diff without fetching every branch.
+                    sh "git fetch --no-tags --force origin ${cfg.baseBranch}:refs/remotes/origin/${cfg.baseBranch}"
+
+                    script {
+                        // Kotlin files changed on this PR vs the merge-base with the base branch.
+                        // Mirrors CircleCI's resolve_changeset (diff-filter=dr drops deletes/renames).
+                        env.KOTLIN_CHANGESET = sh(
+                            returnStdout: true,
+                            script: "git diff --name-only --diff-filter=dr --relative origin/${cfg.baseBranch}...HEAD | grep '\\.kt[s\"]\\?\$' || true"
+                        ).trim()
+                        echo "Kotlin changeset:\n${env.KOTLIN_CHANGESET ?: '(none)'}"
+                    }
+                }
+            }
+
+            stage('ktlint') {
+                steps {
+                    githubStatusWrap('ci/jenkins: ktlint') {
+                        script {
+                            if (!env.KOTLIN_CHANGESET?.trim()) {
+                                echo 'No Kotlin changes — skipping ktlint.'
+                            } else {
+                                sh """
+                                  curl -sSLO https://github.com/pinterest/ktlint/releases/download/${cfg.ktlintVersion}/ktlint
+                                  chmod a+x ktlint
+                                  echo "${env.KOTLIN_CHANGESET}" | xargs ./ktlint --android --relative --disabled_rules=import-ordering --color
+                                """
+                            }
+                        }
+                    }
+                }
+            }
+
+            stage('detekt') {
+                steps {
+                    githubStatusWrap('ci/jenkins: detekt') {
+                        script {
+                            if (!env.KOTLIN_CHANGESET?.trim()) {
+                                echo 'No Kotlin changes — skipping detekt.'
+                            } else {
+                                sh """
+                                  curl -sSLO https://github.com/detekt/detekt/releases/download/v${cfg.detektVersion}/detekt-cli-${cfg.detektVersion}.zip
+                                  unzip -o detekt-cli-${cfg.detektVersion}.zip
+                                  INPUT=\$(echo "${env.KOTLIN_CHANGESET}" | tr '\\n' ',')
+                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "\$INPUT"
+                                """
+                            }
+                        }
+                    }
+                }
+            }
+
+            stage('lint') {
+                steps {
+                    githubStatusWrap('ci/jenkins: lint') {
+                        sh "./gradlew ${cfg.lintTask}"
+                    }
+                }
+            }
+
+            stage('tests') {
+                steps {
+                    githubStatusWrap('ci/jenkins: tests') {
+                        sh "./gradlew ${cfg.unitTestTask}"
+                    }
+                }
+            }
+        }
+
+        post {
+            always {
+                sh 'rm -rf local.properties ktlint detekt-cli-*.zip detekt-cli-*/'
+            }
+        }
+    }
+}

--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -140,10 +140,13 @@ EOF
                                 // Build the comma-separated --input in Groovy: shelling `tr '\n' ','`
                                 // left a trailing comma, so detekt parsed an empty path and crashed.
                                 String input = env.KOTLIN_CHANGESET.readLines().findAll { it?.trim() }.join(',')
+                                // --plugins is optional: some repos (e.g. oneDataProvider) run detekt
+                                // without the formatting plugin. Omit the flag when detektPlugin is blank.
+                                String pluginArg = cfg.detektPlugin ? "--plugins ${cfg.detektPlugin}" : ''
                                 sh """
                                   curl -sSLO https://github.com/detekt/detekt/releases/download/v${cfg.detektVersion}/detekt-cli-${cfg.detektVersion}.zip
                                   unzip -o detekt-cli-${cfg.detektVersion}.zip
-                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "${input}"
+                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} ${pluginArg} --input "${input}"
                                 """
                             }
                         }

--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -77,16 +77,31 @@ EOF
                         '''
                     }
 
-                    // Make the base branch available for the diff without fetching every branch.
-                    sh "git fetch --no-tags --force origin ${cfg.baseBranch}:refs/remotes/origin/${cfg.baseBranch}"
-
                     script {
-                        // Kotlin files changed on this PR vs the merge-base with the base branch.
-                        // Mirrors CircleCI's resolve_changeset (diff-filter=dr drops deletes/renames).
-                        env.KOTLIN_CHANGESET = sh(
-                            returnStdout: true,
-                            script: "git diff --name-only --diff-filter=dr --relative origin/${cfg.baseBranch}...HEAD | grep '\\.kt[s\"]\\?\$' || true"
-                        ).trim()
+                        // Resolve the Kotlin changeset WITHOUT a network fetch — a raw `git fetch`
+                        // in an sh step has no credentials (GIT_ASKPASS is scoped to `checkout scm`).
+                        //
+                        // With PR "merge" discovery, Jenkins checks out a merge commit whose first
+                        // parent is the target-branch tip and second parent is the PR head, so we
+                        // diff those two parents directly. Mirrors CircleCI's resolve_changeset
+                        // (diff-filter=dr drops deletes/renames).
+                        def parents = sh(returnStdout: true, script: 'git rev-list --parents -n 1 HEAD').trim().tokenize(' ')
+                        if (env.CHANGE_ID?.trim() && parents.size() >= 3) {
+                            String target = parents[1]
+                            String prHead = parents[2]
+                            echo "PR #${env.CHANGE_ID}: diffing target ${target} vs PR head ${prHead}"
+                            env.KOTLIN_CHANGESET = sh(
+                                returnStdout: true,
+                                script: "git diff --name-only --diff-filter=dr ${target} ${prHead} | grep '\\.kt[s\"]\\?\$' || true"
+                            ).trim()
+                        } else {
+                            // Not a PR merge build (e.g. a branch build). This job should discover
+                            // PRs only; skip the changeset linters rather than fail, and warn loudly.
+                            echo "WARNING: not a PR merge build (CHANGE_ID='${env.CHANGE_ID}'). " +
+                                 "Configure the Multibranch source for 'Discover pull requests' with the " +
+                                 "merge strategy and remove 'Discover branches'. Skipping ktlint/detekt changeset."
+                            env.KOTLIN_CHANGESET = ''
+                        }
                         echo "Kotlin changeset:\n${env.KOTLIN_CHANGESET ?: '(none)'}"
                     }
                 }

--- a/vars/androidPRVerify.groovy
+++ b/vars/androidPRVerify.groovy
@@ -137,11 +137,13 @@ EOF
                             if (!env.KOTLIN_CHANGESET?.trim()) {
                                 echo 'No Kotlin changes — skipping detekt.'
                             } else {
+                                // Build the comma-separated --input in Groovy: shelling `tr '\n' ','`
+                                // left a trailing comma, so detekt parsed an empty path and crashed.
+                                String input = env.KOTLIN_CHANGESET.readLines().findAll { it?.trim() }.join(',')
                                 sh """
                                   curl -sSLO https://github.com/detekt/detekt/releases/download/v${cfg.detektVersion}/detekt-cli-${cfg.detektVersion}.zip
                                   unzip -o detekt-cli-${cfg.detektVersion}.zip
-                                  INPUT=\$(echo "${env.KOTLIN_CHANGESET}" | tr '\\n' ',')
-                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "\$INPUT"
+                                  ./detekt-cli-${cfg.detektVersion}/bin/detekt-cli --config ${cfg.detektConfig} --plugins ${cfg.detektPlugin} --input "${input}"
                                 """
                             }
                         }

--- a/vars/githubStatusWrap.groovy
+++ b/vars/githubStatusWrap.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/env groovy
+
+/**
+ * Runs `body` while reporting a single GitHub commit status under `context`
+ * (e.g. "ci/jenkins: ktlint"): PENDING before, SUCCESS on clean exit, FAILURE
+ * on throw. Repo + commit SHA are inferred from the checked-out SCM by the
+ * GitHub plugin's githubNotify step.
+ */
+def call(String context, Closure body) {
+    githubNotify context: context, status: 'PENDING', description: 'Running'
+    try {
+        body()
+        githubNotify context: context, status: 'SUCCESS', description: 'Passed'
+    } catch (err) {
+        githubNotify context: context, status: 'FAILURE', description: 'Failed'
+        throw err
+    }
+}

--- a/vars/githubStatusWrap.groovy
+++ b/vars/githubStatusWrap.groovy
@@ -1,18 +1,35 @@
 #!/usr/bin/env groovy
 
 /**
- * Runs `body` while reporting a single GitHub commit status under `context`
- * (e.g. "ci/jenkins: ktlint"): PENDING before, SUCCESS on clean exit, FAILURE
- * on throw. Repo + commit SHA are inferred from the checked-out SCM by the
- * GitHub plugin's githubNotify step.
+ * Runs `body` while reporting a GitHub check named `checkName`
+ * (e.g. "ci/jenkins: ktlint"): IN_PROGRESS before, COMPLETED/SUCCESS on clean
+ * exit, COMPLETED/FAILURE on throw.
+ *
+ * Uses the GitHub Checks plugin's `publishChecks` step. Publishing is best-effort:
+ * if it can't post (plugin/credentials not set up for the Checks API — e.g. a PAT
+ * instead of a GitHub App), it logs a warning rather than failing the build, so the
+ * check's real pass/fail is never masked by a reporting problem. The body's own
+ * failure always propagates.
  */
-def call(String context, Closure body) {
-    githubNotify context: context, status: 'PENDING', description: 'Running'
+def call(String checkName, Closure body) {
+    publish(checkName, 'IN_PROGRESS', null)
     try {
         body()
-        githubNotify context: context, status: 'SUCCESS', description: 'Passed'
+        publish(checkName, 'COMPLETED', 'SUCCESS')
     } catch (err) {
-        githubNotify context: context, status: 'FAILURE', description: 'Failed'
+        publish(checkName, 'COMPLETED', 'FAILURE')
         throw err
+    }
+}
+
+private void publish(String checkName, String status, String conclusion) {
+    try {
+        if (conclusion) {
+            publishChecks name: checkName, status: status, conclusion: conclusion
+        } else {
+            publishChecks name: checkName, status: status
+        }
+    } catch (Throwable t) {
+        echo "Check '${checkName}' (${status}${conclusion ? '/' + conclusion : ''}) not published: ${t.message}"
     }
 }

--- a/version.gradle
+++ b/version.gradle
@@ -51,10 +51,10 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.12"
+version.foundation = "5.5.46"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
-version.foundation_auth = "5.0.55-RC"
+version.foundation_auth = "5.0.58"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
## What

Brings **only QA-tested tickets** from `develop` into `release-candidate` (cut from `master`), so the release can be cut from a tested-only base while QA is a bottleneck.

### version.gradle (tested-latest)
| key | release-candidate | curated | source |
|---|---|---|---|
| `version.foundation` | 5.5.12 | **5.5.46** | OP-17235 (5.5.47 = OP-16478, *Ready for QA* → excluded) |
| `version.foundation_auth` | 5.0.55-RC | **5.0.58** | OP-16299 |
| `version.foundation_release` | 5.5.12-RC4 | *(unchanged)* | release-finish owns it |
| `version.foundation_test_library` | 5.0.10 | *(unchanged)* | 5.0.11 bump is untested |

### OP-17204 — android-ci Jenkins shared library (status: **Done**)
Cherry-picked (7 commits): `vars/androidPRVerify.groovy`, `vars/githubStatusWrap.groovy`, `docs/android-ci.md`, `README.md`. Included because Done counts as tested; **flagging** it as infra — drop from this PR if you'd rather keep it develop-only.

## Excluded (untested)
OP-16478 (foundation 5.5.47, Ready for QA), OP-17309 (Robolectric catalog, In Progress), OP-16278 (Agent PR Ready), AGENCY-7573/7675/7741 & no-ticket chores. `lottie-compose` / Retrofit-OkHttp (AGENCY-7610/7674) are already in release-candidate via master.

## Mechanism
Version pins set to their latest **tested** value directly (replaying interleaved tested/untested bumps would conflict on every line); non-version tested work cherry-picked with `-x`.

Ticket: OP-17339

🤖 Generated with [Claude Code](https://claude.com/claude-code)