### PR TITLE
OP-17339 Record release-candidate ticket manifest (Android-Config)

### DIFF
--- a/.ai/specs/OP-17339-release-candidate-tickets.md
+++ b/.ai/specs/OP-17339-release-candidate-tickets.md
@@ -1,0 +1,31 @@
+# release-candidate ticket manifest (OP-17339)
+
+release-candidate is the long-lived, QA-tested integration branch the release is cut from.
+The initial curation (OP-17339) brought these tested tickets (Jira status Ready to Release /
+Done) from develop into release-candidate. Because the widget/Foundation version pins were
+curated in bulk rather than via one PR per ticket, this manifest records the ticket keys so the
+Widgetizer ticket-tracker (which reads merge-commit messages) can see them on this branch.
+
+## Tested tickets curated into release-candidate (Android-Config)
+
+- AGENCY-7594
+- AGENCY-7610
+- AGENCY-7612
+- AGENCY-7628
+- AGENCY-7674
+- OP-15986
+- OP-16024
+- OP-16239
+- OP-16299
+- OP-16360
+- OP-16490
+- OP-16506
+- OP-16545
+- OP-16643
+- OP-16976
+- OP-17077
+- OP-17111
+- OP-17185
+- OP-17204
+- OP-17216
+- OP-17235


### PR DESCRIPTION
Records the tested tickets curated into release-candidate under OP-17339 so the Widgetizer ticket-tracker (which reads merge-commit messages) sees them on this branch.

**Merge with a merge commit** and keep the keys in the merge-commit body (see the suggested command below) — squash/rebase would drop them.

Tested tickets: AGENCY-7594 AGENCY-7610 AGENCY-7612 AGENCY-7628 AGENCY-7674 OP-15986 OP-16024 OP-16239 OP-16299 OP-16360 OP-16490 OP-16506 OP-16545 OP-16643 OP-16976 OP-17077 OP-17111 OP-17185 OP-17204 OP-17216 OP-17235