### PR TITLE
OP-17339 Set foundation_release to 5.5.46 on release/v26.07

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.46"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.12-RC4"
+version.foundation_release = "5.5.46"
 version.foundation_auth = "5.0.58"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Why
`release/*` builds resolve `version.foundation_release` (via `isReleaseBranch()` in `branch-utils.gradle`), **not** `version.foundation`. On `release/v26.07` it was still **5.5.12-RC4** (the v26.06 release), so every release-branch build — the app and all 55 widgets — compiled against the old Foundation and failed on the Lottie tile API (`TILE_TYPE_LOTTIE`, `LottieTileViewHolder`, new `build(...)` overload). Example: oneWidgetMessages publish failure.

## Change
`version.foundation_release` 5.5.12-RC4 → **5.5.46** — the tested release Foundation (identical to `version.foundation` curated for this release). Auth is unaffected (`version_auth` has no release/latest split; already 5.0.58).

## After merge
Re-run the failing widget publishes; they'll resolve Foundation 5.5.46 and compile.

Note: kept the plain `5.5.46` (already-published, tested artifact). If the team wants `foundation_release` to keep the `-RC` convention, republish Foundation as `5.5.46-RC` and point here instead.

Ticket: OP-17339

🤖 Generated with [Claude Code](https://claude.com/claude-code)