### PR TITLE
OP-16278 [Android][Config] Sync missing lottie + robolectric deps into release/v26.07

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -104,6 +104,10 @@ version.compose_runtime = "2.6.2"
 version.accompanist = "0.30.1"
 // maps-compose
 version.maps_compose = "2.11.4"
+// Lottie-compose
+version.lottie_compose = "6.7.1"
+// robolectric
+version.robolectric = "4.16"
 // end-dependency-version-declaration
 ext.version = version
 
@@ -281,6 +285,10 @@ compose.coil = "io.coil-kt:coil-compose:$version.coil"
 compose.runtime = "androidx.lifecycle:lifecycle-runtime-compose:$version.compose_runtime"
 dependency.compose = compose
 
+def lottie = [:]
+lottie.compose = "com.airbnb.android:lottie-compose:$version.lottie_compose"
+dependency.lottie = lottie
+
 def test = [:]
 test.base = "junit:junit:$version.junit"
 test.jupiter_api = "org.junit.jupiter:junit-jupiter-api:$version.junit_jupiter"
@@ -290,6 +298,7 @@ test.jupiter_plugin = "de.mannodermaus.gradle.plugins:android-junit5:$version.ju
 test.junit_platform_launcher = "org.junit.platform:junit-platform-launcher:$version.junit_platform_launcher"
 test.core_ktx = "androidx.test:core-ktx:$version.core_ktx"
 test.junit_ktx = "androidx.test.ext:junit-ktx:$version.junit_ktx"
+test.robolectric = "org.robolectric:robolectric:$version.robolectric"
 dependency.test = test
 
 def ui_test = [:]


### PR DESCRIPTION
## Problem
Every build of `release/v26.07` fails at configuration time:
```
* What went wrong:
A problem occurred evaluating project ':one-ui-tile'.
> Cannot get property 'compose' on null object   (one-ui-tile/build.gradle:30)
```

`release/v26.07` was cut without two dependency definitions that the release Foundation code needs — they existed on `develop` but were never carried into the release cut:

| Missing def | Referenced by |
|---|---|
| `dependency.lottie` (+ `version.lottie_compose`) | `one-ui-tile/build.gradle:30` — Lottie tile (OP-17185 / OP-17216 / OP-17235) |
| `dependency.test.robolectric` (+ `version.robolectric`) | `platform-main/build.gradle:41` — OP-16478 notification test |

A full audit of every `dependency.*` reference in the release Foundation code vs. this config confirmed these are the **only** two gaps.

## Fix
Add both blocks, mirrored verbatim from `develop`'s `version.gradle`. No version-pointer changes (`version.foundation_release` untouched).

## Validation
Repointed a `release/v26.07` Foundation checkout at this branch's `version.gradle` and ran `:one-ui-tile:help :platform-main:help --refresh-dependencies` → **BUILD SUCCESSFUL** (the null-property error is gone).

## Note
This is an infra/config-sync fix independent of OP-16278's analytics change — it just surfaced because it blocks the OP-16278 release PR (endiosOneFoundation-Android #918). May warrant its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)