### PR TITLE
OP-17357 [Android][Config] Bump version.foundation to 5.5.52

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.51"
+version.foundation = "5.5.52"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) `5.5.51` → `5.5.52` to pick up the dead-View removals in OP-17357.
- `version.foundation_release` (STABLE) is left untouched.

## Merge order
1. [endiosOneFoundation-Android #919](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/919) — merge to `develop` → publishes Foundation `5.5.52`.
2. **This PR** — bump `version.foundation` → 5.5.52. Merge **only after** Foundation `5.5.52` has published, otherwise downstream builds break in the gap.

## Test plan
- Config-only change; verified `version.foundation = "5.5.52"` and `version.foundation_release` unchanged.
