### PR TITLE
OP-16278 Bump version.foundation_release to 5.5.49-RC (release/v26.07)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.46"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.46"
+version.foundation_release = "5.5.49-RC"
 version.foundation_auth = "5.0.58"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
Points `release/v26.07` apps at the Foundation RC published from `release/v26.07` (endiosOneFoundation-Android #918, `pomVersion 5.5.49-RC`) carrying the `endiosVersion 26.7.1` change, so the release train can build/QA it.

On a release branch apps resolve Foundation via `version.foundation_release` (`isReleaseBranch()` → STABLE line). Bumped 5.5.46 → 5.5.49-RC; `version.foundation` (LATEST/develop line) left untouched, matching the per-RC bump pattern used across release/v26.06 (RC → RC2 → RC3 → RC4).

**Merge after** #918 is merged + published so the RC artifact exists on Maven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)