### PR TITLE
OP-17360 [Android][Config] Bump version.foundation to 5.5.54

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.53"
+version.foundation = "5.5.54"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bumps the Foundation LATEST catalog version (`version.foundation`) to **5.5.54**, matching the Foundation publish that adds the Compose `OnePageIndicator` and deprecates the legacy View-based `PageIndicatorView`.

Only `version.foundation` (LATEST) is touched; `version.foundation_release` (STABLE) is untouched.

**Additional Note:**

This is the companion to the Foundation PR below. It must merge **only after** Foundation 5.5.54 has published (i.e. after the Foundation PR merges to `develop`), otherwise downstream builds break in the gap.

## Merge order
1. [endiosOneFoundation-Android #920](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/920) — adds `OnePageIndicator` + deprecation; publishes Foundation 5.5.54 on merge.
2. **This PR** — points the catalog at 5.5.54 (merge only after step 1 publishes).

**Deprecations (if any):**

Reflects the deprecation of `PageIndicatorView` / `OneViewComponentPageIndicatorView` shipped in Foundation 5.5.54.
