### PR TITLE
OP-17293 Bump Foundation LATEST to 5.5.59

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.53"
+version.foundation = "5.5.54"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.54"
+version.foundation = "5.5.56"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.58"
+version.foundation = "5.5.59"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bumps `version.foundation` (LATEST) → `5.5.58` so develop builds pick up the hardware-keyboard operability fix for home-screen tiles.

Companion to endiosOneFoundation-Android#921 (OP-17293). The value was bumped as develop advanced during the release cycle (5.5.54–5.5.57 taken by OP-17360 / OP-17380 / OP-16478 / OP-16278); `5.5.58` is the next free version and matches the Foundation PR's `pomVersion`.

**Additional Note:** Targets `develop` (team trunk). `version.foundation_release` is untouched.

**Deprecations (if any):** None