### PR TITLE
OP-17370 Remove dead oss.sonatype.org repository from Android-Config

### DIFF
--- a/.ai/specs/OP-17370.md
+++ b/.ai/specs/OP-17370.md
@@ -1,0 +1,93 @@
+# Spec: Remove dead oss.sonatype.org repository from Android-Config
+
+**Ticket:** [OP-17370](https://endios.atlassian.net/browse/OP-17370)
+**Created:** 2026-07-16
+**Status:** Draft
+
+## Context
+
+Gradle sync / dependency resolution fails intermittently across all Android repos
+(first observed on `endiosOneApp-Android`). Symptoms look random: a handful of
+endios artifacts (`de.endios.one.core:platform-main`, `oneWidgetOfferWorld`,
+`oneWidgetParking`, `oneWidgetCityGuide`, …) fail to resolve, and many more fail
+when forcing `--refresh-dependencies` / an Android Studio sync.
+
+**Root cause:** `Android-Config`'s `version.gradle` `addRepositories()` declares the
+repository `https://oss.sonatype.org/content/repositories/snapshots` (legacy Sonatype
+OSSRH, now end-of-life) **before** `https://mvn.endios.de/android`, which is where all
+endios artifacts actually live. `oss.sonatype.org` now times out / returns
+`504 Gateway Time-out`. Gradle treats a `504` (server error) as **fatal** — unlike a
+`404`, which falls through to the next repository — so resolution aborts at Sonatype and
+never reaches `mvn.endios.de`, even though the artifact exists there.
+
+It looks random because already-cached artifacts resolve fine; only cache-miss artifacts
+(recently bumped versions) hit the dead host, and `--refresh-dependencies` / IDE sync
+re-queries everything.
+
+Verified in the ticket:
+- Failing artifacts return HTTP 200 from `mvn.endios.de` with valid pull credentials.
+- `oss.sonatype.org` times out (30s, no response) / returns 504.
+- Gradle error: `Could not HEAD '.../oss.sonatype.org/.../platform-main-5.5.53.pom'. Received status code 504 from server: Gateway Time-out`.
+
+Because `addRepositories()` is imported by every Android repo, this single shared-config
+change fixes every repo and CI job at once.
+
+## Requirements
+
+### Functional
+- Remove the repository declaration `handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }`
+  from the `addRepositories(RepositoryHandler handler)` function in `version.gradle`.
+- After removal, `addRepositories()` declares exactly: `google()`, `mavenCentral()`,
+  `mvn.endios.de/android` (with pull credentials), `mavenLocal()` — in that order.
+- Snapshot hosting is not needed (endios artifacts are release artifacts on
+  `mvn.endios.de`); the Sonatype snapshots endpoint is dropped entirely rather than
+  repointed at the current Sonatype Central snapshots URL.
+
+### Non-Functional
+- No behavior change to any other repository declaration — `mvn.endios.de` credentials and
+  ordering (remote checked before `mavenLocal()`) are preserved.
+
+## Behaviors (verification plan)
+
+This is a Gradle repository-configuration change — there is no unit-testable production
+code, so each behavior below is verified by Gradle repository resolution rather than a
+red-green-refactor test.
+
+1. [ ] Given `addRepositories()`, when the repository list is inspected, then no repository with a URL containing `oss.sonatype.org` is declared.
+2. [ ] Given `addRepositories()`, when the repository list is inspected, then it declares `google()`, `mavenCentral()`, `https://mvn.endios.de/android` (with pull credentials), and `mavenLocal()` in that order.
+3. [ ] Given a consuming repo (e.g. `endiosOneApp-Android`) with a cache-miss endios artifact, when Gradle resolves dependencies with `--refresh-dependencies`, then resolution succeeds without a `504`/HEAD failure against `oss.sonatype.org`.
+
+## Technical Notes
+
+- **Affected files/modules:** `Android-Config/version.gradle` — line 341 (the single
+  `oss.sonatype.org` `handler.maven { … }` line inside `addRepositories()`, ~lines 338–350).
+- **Stack considerations:** Groovy Gradle script; `addRepositories` is exported via
+  `ext.addRepositories` and imported by every Android repo's root `build.gradle`.
+- **Architecture constraints:** Preserve `mvn.endios.de` before `mavenLocal()` ordering
+  (remote is checked before local — see project KB).
+- **Sibling references:** Confirmed none — `oss.sonatype.org` / snapshot repos appear only
+  at `version.gradle:341`; `maven.gradle` and all other sibling `.gradle` files are clean.
+- **Dependencies:** none removed from the catalog; only a repository source is dropped.
+
+## Affected repositories
+
+**Primary change (this ticket):**
+- **Android-Config** — remove the `oss.sonatype.org` repo from `addRepositories()` in `version.gradle`.
+
+**Repos that benefit automatically (no change needed — they import `addRepositories()`):**
+- **endiosOneApp-Android** and all Foundation / widget repos + CI — resolution unblocked once
+  they pick up the updated `Android-Config`.
+
+## Open Questions
+
+- None. Root cause and fix are fully specified in the ticket; snapshot hosting confirmed
+  unneeded.
+
+## QA
+
+**Recommended app:** _not applicable — build-configuration change with no runtime surface._
+**Environment:** n/a
+**Reason:** This removes a dead Maven repository from the shared config; verification is a
+Gradle dependency-resolution check (e.g. `./gradlew help --refresh-dependencies` on
+`endiosOneApp-Android` succeeds with no `oss.sonatype.org` HEAD failure), not an app QA pass.
+**Alternatives considered:** none.

--- a/.ai/specs/OP-17370.md
+++ b/.ai/specs/OP-17370.md
@@ -2,7 +2,7 @@
 
 **Ticket:** [OP-17370](https://endios.atlassian.net/browse/OP-17370)
 **Created:** 2026-07-16
-**Status:** Draft
+**Status:** Implemented
 
 ## Context
 
@@ -53,9 +53,9 @@ This is a Gradle repository-configuration change — there is no unit-testable p
 code, so each behavior below is verified by Gradle repository resolution rather than a
 red-green-refactor test.
 
-1. [ ] Given `addRepositories()`, when the repository list is inspected, then no repository with a URL containing `oss.sonatype.org` is declared.
-2. [ ] Given `addRepositories()`, when the repository list is inspected, then it declares `google()`, `mavenCentral()`, `https://mvn.endios.de/android` (with pull credentials), and `mavenLocal()` in that order.
-3. [ ] Given a consuming repo (e.g. `endiosOneApp-Android`) with a cache-miss endios artifact, when Gradle resolves dependencies with `--refresh-dependencies`, then resolution succeeds without a `504`/HEAD failure against `oss.sonatype.org`.
+1. [x] Given `addRepositories()`, when the repository list is inspected, then no repository with a URL containing `oss.sonatype.org` is declared. _(verified: diff removed the only occurrence; repo-wide grep for `sonatype`/`snapshots` returns nothing.)_
+2. [x] Given `addRepositories()`, when the repository list is inspected, then it declares `google()`, `mavenCentral()`, `https://mvn.endios.de/android` (with pull credentials), and `mavenLocal()` in that order. _(verified from the resulting function body.)_
+3. [ ] Given a consuming repo (e.g. `endiosOneApp-Android`) with a cache-miss endios artifact, when Gradle resolves dependencies with `--refresh-dependencies`, then resolution succeeds without a `504`/HEAD failure against `oss.sonatype.org`. _(pending: full-resolution check runs in CI / on a consuming repo — not exercised in this change.)_
 
 ## Technical Notes
 

--- a/version.gradle
+++ b/version.gradle
@@ -338,7 +338,6 @@ ext.dependency = dependency
 def addRepositories(RepositoryHandler handler) {
     handler.google()
     handler.mavenCentral()
-    handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     handler.maven {
         url 'https://mvn.endios.de/android'
         credentials {


### PR DESCRIPTION
**Ticket:** [OP-17370](https://endios.atlassian.net/browse/OP-17370 "Link to JIRA")

**Purpose of this Pull Request:**

Removes the dead `oss.sonatype.org/content/repositories/snapshots` repository from `addRepositories()` in `version.gradle`.

The legacy Sonatype OSSRH snapshots host is end-of-life and now returns `504 Gateway Time-out`. Because it was declared **before** `mvn.endios.de` and Gradle treats a `504` (server error) as fatal — unlike a `404`, which falls through to the next repository — dependency resolution aborted at Sonatype and never reached the repo that actually holds all endios artifacts. This intermittently broke Gradle sync / `--refresh-dependencies` for any cache-miss (recently bumped) artifact across **every** Android repo and CI job.

Since `addRepositories()` is imported by all Android repos, this single shared-config change unblocks resolution everywhere at once. Snapshot hosting is not needed (endios artifacts are release artifacts on `mvn.endios.de`), so the endpoint is dropped entirely rather than repointed at Sonatype Central.

After removal, `addRepositories()` declares: `google()` → `mavenCentral()` → `mvn.endios.de/android` (with pull credentials) → `mavenLocal()`.

**Companion PRs (same fix on the other long-lived branches):**
- master: https://github.com/endiosGmbH/Android-Config/pull/817
- release/v26.07: https://github.com/endiosGmbH/Android-Config/pull/818

**Additional Note:**

- Confirmed the `oss.sonatype.org` reference existed **only** at `version.gradle:341` — `maven.gradle` and all sibling `.gradle` files are clean.
- Spec: `.ai/specs/OP-17370.md`.
- Verified via a before/after `addRepositories()` repository-list check through the real raw-URL `apply from` path: `develop` lists sonatype at index [2]; this branch does not, with `mvn.endios.de` + `mavenLocal` order and credentials preserved.

**Deprecations (if any):** None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-17370]: https://endios.atlassian.net/browse/OP-17370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ