### PR TITLE
OP-17370 Remove dead oss.sonatype.org repository from Android-Config (release/v26.07)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -337,7 +337,6 @@ ext.dependency = dependency
 def addRepositories(RepositoryHandler handler) {
     handler.google()
     handler.mavenCentral()
-    handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     handler.maven {
         url 'https://mvn.endios.de/android'
         credentials {


### PR DESCRIPTION
**Ticket:** [OP-17370](https://endios.atlassian.net/browse/OP-17370 "Link to JIRA")

**Purpose of this Pull Request:**

Backports the `oss.sonatype.org` removal to `release/v26.07` so the v26.07 release build and any consumer pinned to this release branch are unblocked.

The legacy Sonatype OSSRH snapshots host is end-of-life and returns `504 Gateway Time-out`. Declared **before** `mvn.endios.de` and with Gradle treating a `504` as fatal (unlike a `404`, which falls through), dependency resolution aborted at Sonatype and never reached the repo holding all endios artifacts — intermittently breaking Gradle sync / `--refresh-dependencies` for any cache-miss artifact across every Android repo and CI job.

After removal, `addRepositories()` declares: `google()` → `mavenCentral()` → `mvn.endios.de/android` (with pull credentials) → `mavenLocal()`.

**Companion PRs:**
- develop: https://github.com/endiosGmbH/Android-Config/pull/816
- master: https://github.com/endiosGmbH/Android-Config/pull/817

**Additional Note:** version.gradle-only change — no `version.*` / `-RC` values touched. Verified via before/after `addRepositories()` repository-list check through the raw-URL `apply from` path (sonatype gone, order + credentials preserved).

**Deprecations (if any):** None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-17370]: https://endios.atlassian.net/browse/OP-17370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ