### PR TITLE
OP-17380 [Android][Config] Bump version.foundation to 5.5.55

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.54"
+version.foundation = "5.5.55"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bump `version.foundation` (LATEST) 5.5.54 → 5.5.55.
- Companion to the Foundation `one-ui-help` PageIndicatorView → OnePageIndicator migration (OP-17380).
- `version.foundation_release` (STABLE) untouched.

## Merge order
1. endiosGmbH/endiosOneFoundation-Android#923 (Foundation) — publishes 5.5.55 on merge to `develop`.
2. **This PR** (Android-Config) — merge only **after** Foundation 5.5.55 is published, or downstream builds break in the gap.
