### PR TITLE
OP-16478 Bump version.foundation to 5.5.56

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.55"
+version.foundation = "5.5.56"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
Bumps `version.foundation` to **5.5.56**, published by endiosOneFoundation-Android for OP-16478 (background notification `Open` events now carry `analytics_label` / `url` / `widgetId`).

## Merge order

1. Foundation — https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/925 (merge first, wait for Maven publish of 5.5.56).
2. **This PR** — `version.foundation = 5.5.56` (merge only after 5.5.56 is published, else downstream builds break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
