### PR TITLE
OP-16278 Bump foundation_release to 5.5.49-RC2 (endiosVersion 26.7.0)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.46"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.49-RC"
+version.foundation_release = "5.5.49-RC2"
 version.foundation_auth = "5.0.58"
 version.foundation_test_library = "5.0.10"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Summary
- Companion to endiosOneFoundation-Android PR #926.
- Bumps `version.foundation_release` (STABLE, used by `release/*`) `5.5.49-RC` → `5.5.49-RC2` so `release/v26.07` app builds resolve the Foundation AAR that emits `data.endiosVersion = 26.7.0`.

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/926

## Test plan
- Release-branch app build resolves `foundation:5.5.49-RC2`; QA verifies `data.endiosVersion == "26.7.0"` per PR #926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)