### PR TITLE
OP-16278 Bump foundation to 5.5.57 (endiosVersion 26.7.0, YY.M.0)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.55"
+version.foundation = "5.5.56"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.56"
+version.foundation = "5.5.57"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Companion to endiosOneFoundation-Android PR #927.
- Bumps `version.foundation` (LATEST) `5.5.55` → `5.5.56` so `develop` app builds resolve the Foundation AAR that emits `data.endiosVersion = 26.7.0` under the pinned `YY.M.0` format.
- `version.foundation_release` is untouched.

## Companion PRs
- Foundation: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/927

## Test plan
- Develop app build resolves `foundation:5.5.56`; `data.endiosVersion == "26.7.0"` per PR #927.

🤖 Generated with [Claude Code](https://claude.com/claude-code)