### PR TITLE
OP-17417 [Android][Config] Bump version.foundation to 5.5.58

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.56"
+version.foundation = "5.5.57"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bumps `version.foundation` (LATEST) `5.5.56` → `5.5.57` to pick up the `OneBadgeLayout` → Compose conversion (OP-17417). `version.foundation_release` (STABLE) is untouched.

⚠️ **Merge only AFTER Foundation 5.5.57 is published to Maven** (manual `workflow_dispatch` on the Foundation PR), otherwise every downstream build breaks in the gap.

## Merge order

1. Foundation — 5.5.57, publish after merge. → https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/929
2. **This PR** — `version.foundation` → 5.5.57 (merge only after the artifact is published). → https://github.com/endiosGmbH/Android-Config/pull/825
3. oneWidgetOffers — migrate the `badgeAlert` caller, pomVersion → 5.0.30 (auto-publishes on merge). → https://github.com/endiosGmbH/oneWidgetOffers-Android/pull/375
4. endiosOneApp — bump Offers pins (`OffersBasic`/`OffersLarge`/`OfferWorld`) → 5.0.30. → https://github.com/endiosGmbH/endiosOneApp-Android/pull/2620
5. Foundation-Check — verify only (independent).

Ticket: [OP-17417](https://endios.atlassian.net/browse/OP-17417)


[OP-17417]: https://endios.atlassian.net/browse/OP-17417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ