### PR TITLE
OP-17294 Bump foundation to 5.5.58

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.56"
+version.foundation = "5.5.58"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) → `5.5.58` for the Foundation Compose focus-ring work (Track B of OP-17294).

## ⚠️ Merge order
Must merge **after** the tile-track companion #824 (5.5.57).

## Companion PR
- endiosGmbH/endiosOneFoundation-Android#930

🤖 Generated with [Claude Code](https://claude.com/claude-code)