### PR TITLE
OP-16307 Bump Foundation Auth to 5.0.59

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -54,7 +54,7 @@ version.firebase_messaging = "23.0.7"
 version.foundation = "5.5.57"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
-version.foundation_auth = "5.0.58"
+version.foundation_auth = "5.0.59"
 version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"
 // google


### PR DESCRIPTION
Companion to endiosOneFoundation-Auth-Android#94.

Bumps `version.foundation_auth` (LATEST) 5.0.58 → 5.0.59 — custom-scheme redirectUri handling in the OAuth login WebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)