### PR TITLE
OP-17423 [Android][Foundation] Bump version.foundation to 5.5.60 (Compose OneSlider)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.59"
+version.foundation = "5.5.60"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Ticket:** [OP-17423](https://endios.atlassian.net/browse/OP-17423 "Link to JIRA")

**Purpose of this Pull Request:**
Bump the catalog `version.foundation` `5.5.57` → `5.5.60` so the new Compose `OneSlider` (added to `one-core-compose` in Foundation) resolves for all downstream widgets. Phase 1 (deprecate) of the OneSeekBar → OneSlider conversion (parent OP-17422).

**Additional Note:**
Only `version.foundation` (LATEST) is bumped — `version.foundation_release` (STABLE) is untouched. Merge **only after** Foundation `5.5.60` is published to Maven, otherwise every downstream build breaks in the gap.

**Deprecations (if any):**
None in this repo. (The Foundation PR deprecates the View-based `OneSeekBar`.)

## Merge order
1. [Foundation #931](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/931) — add `OneSlider` + deprecate `OneSeekBar`, publish 5.5.60
2. **This PR** — `Android-Config` `version.foundation` → 5.5.60 (after publish)
3. Phase 2 widget migrations (OP-17425 Photovoltaic, OP-17426 PublicTransport, OP-17427 WindAndSurf, OP-17428 Sample) → OP-17429 app pin bumps
4. Phase 3 deletion — OP-17430 (removes `OneSeekBar`/`OneSeekBarExt`, gated on zero live consumers)

[OP-17423]: https://endios.atlassian.net/browse/OP-17423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

