### PR TITLE
OP-17430 [Android][Foundation] Bump version.foundation to 5.5.61 (OneSeekBar/Slider View-chain delete)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.60"
+version.foundation = "5.5.61"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"

--- a/version.gradle
+++ b/version.gradle
@@ -51,11 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-<<<<<<< HEAD
 version.foundation = "5.5.62"
-=======
-version.foundation = "5.5.62"
->>>>>>> origin/develop
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.61"
+version.foundation = "5.5.62"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` 5.5.60 → 5.5.62 to adopt the Foundation cleanup in OP-17430 (deletes the legacy View `OneSeekBar`/`OneSlider`/`OneRangeSlider` chain + orphaned theme styles).
- Purely adopts the cleanup — already-migrated widgets don't reference the deleted APIs, so nothing is gated on this for compilation.

## Test plan
- Version-catalog-only change; no code. Downstream resolves Foundation 5.5.62 once it is published.

## Merge order
1. endiosOneFoundation-Android#932 (delete) — merge, then publish 5.5.62 to Maven.
2. **This PR** — merge only **after** 5.5.62 is live on Maven, or downstream builds break in the gap.
