### PR TITLE
OP-17444 [Android][Foundation] Bump version.foundation to 5.5.63 (remove stale Compose OneSwitch)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.62"
+version.foundation = "5.5.63"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bumps `version.foundation` `5.5.62` → `5.5.63`, adopting the Foundation build that removes the duplicate/stale Compose `OneSwitch` (OP-17444). No consumer change — the removed package had zero references.

**Additional Note:**

Only bumps `version.foundation` (LATEST); `version.foundation_release` (STABLE) is untouched.

## Merge order
1. [endiosOneFoundation-Android#933](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/933) — delete stale Compose OneSwitch (must merge + publish 5.5.63 first)
2. **This PR** — bump `version.foundation` → 5.5.63 (merge only after 5.5.63 is on Maven)
