### PR TITLE
OP-17078 Bump Foundation LATEST to 5.5.66

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.62"
+version.foundation = "5.5.63"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.63"
+version.foundation = "5.5.66"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST development) `5.5.65` → `5.5.66`.
- Companion to endiosOneFoundation-Android#934. Rebased over develop: OP-17078 moved from 5.5.63 to **5.5.66** after a version collision with OP-17444 (also took 5.5.63) and develop advancing through 5.5.64/5.5.65.

## Companion PRs
- endiosOneFoundation-Android#934 — OP-17078 Push tap opens Bonus Points widget via widgetType deep-link (publishes Foundation 5.5.66).

## Test plan
- Config-only version bump; validated by the app resolving Foundation 5.5.66 from Maven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)