### PR TITLE
OP-17461 [Android][Config] Bump version.foundation to 5.5.64

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.62"
+version.foundation = "5.5.64"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST) to `5.5.64`, picking up the Foundation change that deletes the dead deprecated View `OneTextureVideoView` (zero shipping consumers).
- `version.foundation_release` (STABLE) is untouched.

Companion to the Foundation deletion PR. Merge only **after** Foundation `5.5.64` is published to Maven.

## Merge order
1. [endiosOneFoundation-Android #935](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/935) — delete `OneTextureVideoView` + publish `5.5.64` (Maven upload)
2. **This PR** — bump `version.foundation` → `5.5.64`
