### PR TITLE
OP-17463 Bump version.foundation to 5.5.65 (OneSpinner View delete)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.62"
+version.foundation = "5.5.65"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` (LATEST only) 5.5.62 → 5.5.65 to pick up the Foundation build that deletes the unused `OneSpinner` View.
- **Merge only after** Foundation 5.5.65 is published to Maven.

⚠️ Depends on the Foundation 5.5.65 publish. Note develop currently reads 5.5.62 (OP-17444→5.5.63, OP-17461→5.5.64 catalog bumps are separate pending PRs); coordinate merge order so the catalog never points ahead of what is published. Re-bumped 5.5.64 → 5.5.65 after OP-17461 took the 5.5.64 slot.

## Merge order
1. [Foundation — delete OneSpinner](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/936) — merge, then trigger the manual Foundation publish of 5.5.65
2. [Foundation-Check — drop OneSpinner from OneTextView harness](https://github.com/endiosGmbH/endiosOneFoundation-Check-Android/pull/25) — ✅ merged
3. **This PR** — merge only after 5.5.65 is published
