### PR TITLE
OP-17360 [Android][Config] Bump version.foundation to 5.5.67

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.66"
+version.foundation = "5.5.67"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
Bumps `version.foundation` (LATEST) `5.5.66` → `5.5.67`, adopting the Foundation build that deletes the deprecated View `PageIndicatorView` + its base (Phase 4 of OP-17360). `version.foundation_release` (STABLE) is untouched.

Merge only **after** Foundation 5.5.67 is published to Maven.

## Merge order
1. [endiosOneFoundation-Android #937](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/937) — delete `PageIndicatorView` + base, publish 5.5.67 (Maven upload)
2. **This PR** — bump `version.foundation` → 5.5.67