### PR TITLE
OP-17478 [Android][Config] Bump version.foundation to 5.5.68

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.67"
+version.foundation = "5.5.68"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary
- Bumps `version.foundation` → 5.5.68 to pick up the Compose `OneHeader` + `OneHeaderView` deprecation from Foundation. (Re-bumped from 5.5.67 after OP-17360 #834 claimed 5.5.67 on develop.)

## Merge order
1. [Foundation #938](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/938) — Add Compose `OneHeader` + deprecate `OneHeaderView` (must publish 5.5.68 first)
2. **This PR** — bump `version.foundation` → 5.5.68

## Test plan
- Config-only version bump; verified against the Foundation PR's `pomVersion` (5.5.68).