### PR TITLE
OP-17491 Bump version.foundation to 5.5.74

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.73"
+version.foundation = "5.5.74"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
Bumps `version.foundation` (LATEST) to **5.5.74** — the Foundation release that adds the Compose `OneItemInfoRow` + deprecates the View `OneItemInfoRowView` (OP-17491).

Companion to the Foundation PR. One artifact per PR (`version.foundation` only). Merge **after** Foundation 5.5.74 has published to Maven.

## Merge order
1. [Foundation #939 — Add Compose OneItemInfoRow + deprecate View](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/939) — publishes Foundation 5.5.74
2. **This PR** — bumps `version.foundation` → 5.5.74 (merge after #1 publishes)
