### PR TITLE
OP-17116 Bump version.foundation to 5.5.71

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.69"
+version.foundation = "5.5.71"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
**Purpose of this Pull Request:**

Bumps `version.foundation` → **5.5.71** to pick up the Foundation change in [OP-17116](https://endios.atlassian.net/browse/OP-17116) (Compose-native `OneBottomBar`).

**Additional Note:**

Merge only **after** Foundation 5.5.71 has published to Maven (publish gate).

**Deprecations (if any):**

None.

## Merge order
1. [Foundation #940](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/940) (`OneBottomBar`, `pomVersion` → **5.5.71**) — merge first, wait for Maven publish.
2. **This PR** (`version.foundation` → **5.5.71**) — merge after Foundation 5.5.71 publishes.

> ⚠️ Re-bumped 5.5.70 → **5.5.71**: OP-17456 merged first and took 5.5.70 on Foundation `develop`. (Earlier re-bump: 5.5.69 → 5.5.70 after OP-17374 took 5.5.69.)

[OP-17116]: https://endios.atlassian.net/browse/OP-17116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
