### PR TITLE
OP-17456 [Android][Android-Config] Bump version.foundation to 5.5.70

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.69"
+version.foundation = "5.5.70"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
**Ticket:** [OP-17456](https://endios.atlassian.net/browse/OP-17456 "Link to JIRA")

**Purpose of this Pull Request:**

Bumps `version.foundation` to **5.5.70**, which carries the `OneDialog` loading-state layout fix — the spinner rendered beside its message and, with a long message, outside the dialog background.

**Additional Note:**

Merge only **after** Foundation 5.5.70 has published, per the publish gate.

`develop` was already at 5.5.69 while the open Foundation PRs [#939](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/939) (OP-17491) and [#940](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/940) (OP-17116) also claim 5.5.69 — they will need re-bumping independently of this ticket.

**Deprecations (if any):**

None.

## Merge order

1. [Foundation — fix loading state layout for OneDialog](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/941), published as 5.5.70
2. **This PR** — bump `version.foundation` to 5.5.70
3. [Foundation-Check — OneDialog loading-state geometry tests](https://github.com/endiosGmbH/endiosOneFoundation-Check-Android/pull/26)


[OP-17456]: https://endios.atlassian.net/browse/OP-17456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ