### PR TITLE
OP-17110 Bump version.foundation to 5.5.72

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.71"
+version.foundation = "5.5.72"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
Companion to [endiosOneFoundation-Android#942](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/942) — Foundation 5.5.72 fixes the `AddressBottomSheetPicker` address field rendering as a solid white box on dark-background tenants ([OP-17110](https://endios.atlassian.net/browse/OP-17110), reopened after QA).

Merge only after Foundation 5.5.72 is published to Maven.

## Merge order

1. [endiosOneFoundation-Android#942](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/942) — pomVersion → 5.5.72
2. **This PR** — `version.foundation` → 5.5.72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-17110]: https://endios.atlassian.net/browse/OP-17110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ