### PR TITLE
OP-17560 Bump version.foundation to 5.5.73

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.72"
+version.foundation = "5.5.73"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
## What

Bumps `version.foundation` to **5.5.73**, which exposes navigation3 as `api` in `one-core-compose` and `one-ui-compose` so consumers can resolve the nav types those modules already hand them.

Merge only after Foundation 5.5.73 has published to `mvn.endios.de`.

## Merge order

1. [Foundation — expose navigation3 as api](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/943) — publishes 5.5.73
2. **This PR** — bump `version.foundation` to 5.5.73
3. [Foundation-Check — `OneBottomBar` host screen](https://github.com/endiosGmbH/endiosOneFoundation-Check-Android/pull/27)

