### PR TITLE
OP-17397 Bump version.foundation to 5.5.75

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.74"
+version.foundation = "5.5.75"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
Picks up the Foundation fix for text fields rendering as an opaque white box on tenants with a dark app background — [OP-17397](https://endios.atlassian.net/browse/OP-17397).

## Merge order

1. `endiosOneFoundation-Android` [#944](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/944) — Foundation 5.5.75
2. **This PR** — `version.foundation` → 5.5.75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OP-17397]: https://endios.atlassian.net/browse/OP-17397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ