### PR TITLE
Update foundation_release to v26.07 release version

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -53,7 +53,7 @@ version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
 version.foundation = "5.5.75"
 // foundation - STABLE release version (used by release/* branches)
-version.foundation_release = "5.5.12-RC4"
+version.foundation_release = "5.5.49-RC2"
 version.foundation_auth = "5.0.59"
 version.foundation_test_library = "5.0.11"
 version.one_core_compose = "4.26.58"


### PR DESCRIPTION
## Back-merge for v26.07 — Android-Config special case

Android-Config does **not** get a blanket `release/v26.07 → develop` back-merge: that would
overwrite develop's LATEST catalog values with the release branch's RC values. Instead this is a
`backmerge/v26.07` branch cut from `develop`, moving only the STABLE pointer.

### The one change

`version.foundation_release`: `5.5.12-RC4` → `5.5.49-RC2`

That is the Foundation version v26.07 actually shipped, and it is what `master` already serves.
develop's pointer was still on `5.5.12-RC4`, so without this the next release cut would start
from a stale Foundation.

### Deliberately unchanged

| Key | Value on develop | Why it stays |
|---|---|---|
| `version.foundation` | `5.5.75` | LATEST development version — must not regress to a release RC |
| `version.foundation_auth` | `5.0.59` | develop is ahead of the release branch's `5.0.58` |
| `version.foundation_test_library` | `5.0.11` | untouched by the release |

Verified before pushing: the diff is exactly one line.