### PR TITLE
OP-17637 release-candidate: Foundation 5.5.46 → 5.5.49-RC2 (companion)

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.46"
+version.foundation = "5.5.49-RC2"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.12-RC4"
 version.foundation_auth = "5.0.58"


### PR DESCRIPTION
## Summary

Companion to **endiosOneApp-Android#2655** (release-candidate round-2 curation). Bumps `release-candidate`'s `version.foundation` from `5.5.46` to `5.5.49-RC2`.

## Why

OP-17208 (Ready to Release) rebuilt the CityGuide / ECharging / Parking / BonusPoints widgets to be binary-compatible with **Foundation 5.5.49**. That Foundation is published as artifact **`5.5.49-RC2`** — there is no plain `5.5.49` build; the RC2 is the release artifact, and it is the same version `develop` already carries as `version.foundation_release`. Leaving RC at 5.5.46 would risk `NoSuchMethodError` at runtime for those widgets.

The app's `release-candidate` consumes `version.foundation` (it is not a `release/*` branch, so `isReleaseBranch()` is false), which is why this bump is on that field.

## Scope

- `version.foundation`: `5.5.46` → `5.5.49-RC2`
- `version.foundation_release`: **unchanged** (`5.5.12-RC4`) — RC flow does not touch it
- `version.foundation_auth`: **unchanged** (`5.0.58`) — no curated ticket bumps auth this round. Worth a quick ABI sanity check (auth 5.0.58 against Foundation 5.5.49-RC2) during review.

**Merge together with endiosOneApp-Android#2655.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)