### PR TITLE
OP-17652 widget-publish: tag + GitHub Release every published version

### DIFF
--- a/.github/workflows/widget-publish.yml
+++ b/.github/workflows/widget-publish.yml
@@ -25,7 +25,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # write is needed to push the version tag and create the GitHub Release below.
+      # The tag/release step is best-effort: if the caller's GITHUB_TOKEN is capped to
+      # read (org/repo default), it emits a ::warning:: and never fails the publish.
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -56,3 +59,43 @@ jobs:
             ./gradlew :$module:publish
             echo "::endgroup::"
           done
+
+      # Tag the published pomVersion and cut a GitHub Release for visibility, and so that
+      # release-start can later recover the exact source of any published version by tag.
+      # Strictly best-effort: any failure (e.g. a read-only token) warns but never fails the
+      # publish. Idempotent: an already-existing tag is skipped.
+      - name: Tag published version and create GitHub Release
+        if: success()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Resolve the single repo-wide published version: the literal pomVersion string
+          # (root build.gradle first, else the first module build.gradle). Values that are a
+          # Gradle reference (contain '$', e.g. "${rootProject.ext.pomVersion}") are skipped.
+          VER=$(grep -oE 'pomVersion[[:space:]]*=[[:space:]]*"[^"$]+"' build.gradle 2>/dev/null \
+                | grep -oE '"[^"]+"' | tr -d '"' | head -1)
+          if [ -z "$VER" ]; then
+            VER=$(grep -rhoE 'pomVersion[[:space:]]*=[[:space:]]*"[^"$]+"' --include=build.gradle . 2>/dev/null \
+                  | grep -oE '"[^"]+"' | tr -d '"' | head -1)
+          fi
+          if [ -z "$VER" ]; then
+            echo "::warning::Could not resolve a literal pomVersion; skipping tag/release."
+            exit 0
+          fi
+          echo "Resolved published version: $VER"
+
+          # Idempotent: skip if a Release for this version already exists (re-run / unchanged version).
+          if gh release view "$VER" >/dev/null 2>&1; then
+            echo "Release $VER already exists; nothing to do."
+            exit 0
+          fi
+
+          # -RC / any suffixed version is a pre-release so it doesn't take the "Latest release" badge.
+          PRERELEASE=""
+          case "$VER" in *-*) PRERELEASE="--prerelease";; esac
+
+          # Creates the tag ($VER) at this commit AND the Release in one call (needs contents: write).
+          # No local git identity required — the ref is created server-side via the API.
+          gh release create "$VER" --target "$GITHUB_SHA" --title "$VER" --generate-notes $PRERELEASE \
+            || echo "::warning::Failed to create tag/Release $VER (Actions token is likely read-only; set the repo/org default workflow permissions to read-and-write)."


### PR DESCRIPTION
## Summary

Phase 1 of OP-17652. Adds a best-effort step to the shared `widget-publish.yml` (reused by all **53** widgets via `@develop`) that, after a successful publish, creates a **git tag** named exactly the published `pomVersion` and a **GitHub Release** for it.

- `gh release create "$VER" --target "$GITHUB_SHA" --generate-notes` — auto notes from merged PRs, tag created server-side (no CI git identity needed).
- `--prerelease` for any suffixed version (e.g. `-RC`), so pre-releases don't grab the repo's "Latest release" badge but still get a tag + Release.
- **Idempotent** — skips if a Release for that version already exists.
- Resolves the repo-wide literal `pomVersion` (root `build.gradle`, else first module), ignoring `${…}` references.

## Why

1. **Visibility** — a per-widget published-version history with change notes (long-wanted).
2. **Source anchors for Phase 2** — `release-start` will rebuild each app-pinned widget version against the *release* Foundation and publish it as `<pin>-RC`; recovering "the exact source of version X" needs a tag for X. Today there are **zero** tags, so held-back versions (e.g. offers `5.0.46`) can only be found via `git log -S`. Tagging fixes that going forward.

## Safety

- Gated on `if: success()` (only tags when the publish succeeded) + `continue-on-error: true` — a tagging hiccup can **never** fail a publish.
- Needs `contents: write` (bumped from `read`). Effective token is capped by the caller's default. **If your org/repo default workflow permission is read-only**, the step logs a `::warning::` and skips — no per-widget edits, just flip Settings → Actions → General → *Workflow permissions* to **read and write** and it starts working. I couldn't read that setting (needs admin scope) — please confirm.

## ⚠️ Blast radius

Widgets pin this workflow `@develop`, so this goes live for **every** widget publish (develop + release/**) the moment it merges. The step is additive and isolated; existing build/publish behavior is unchanged.

## Follow-up

Phase 2 (`release-start` publishing widget `-RC`s against `version.foundation_release` + repointing app pins) is a separate toolbox PR, tracked on OP-17652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)