### PR TITLE
OP-17652 Revert widget-publish tag/Release step (unblock publishing)

### DIFF
--- a/.github/workflows/widget-publish.yml
+++ b/.github/workflows/widget-publish.yml
@@ -25,10 +25,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      # write is needed to push the version tag and create the GitHub Release below.
-      # The tag/release step is best-effort: if the caller's GITHUB_TOKEN is capped to
-      # read (org/repo default), it emits a ::warning:: and never fails the publish.
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -59,43 +56,3 @@ jobs:
             ./gradlew :$module:publish
             echo "::endgroup::"
           done
-
-      # Tag the published pomVersion and cut a GitHub Release for visibility, and so that
-      # release-start can later recover the exact source of any published version by tag.
-      # Strictly best-effort: any failure (e.g. a read-only token) warns but never fails the
-      # publish. Idempotent: an already-existing tag is skipped.
-      - name: Tag published version and create GitHub Release
-        if: success()
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Resolve the single repo-wide published version: the literal pomVersion string
-          # (root build.gradle first, else the first module build.gradle). Values that are a
-          # Gradle reference (contain '$', e.g. "${rootProject.ext.pomVersion}") are skipped.
-          VER=$(grep -oE 'pomVersion[[:space:]]*=[[:space:]]*"[^"$]+"' build.gradle 2>/dev/null \
-                | grep -oE '"[^"]+"' | tr -d '"' | head -1)
-          if [ -z "$VER" ]; then
-            VER=$(grep -rhoE 'pomVersion[[:space:]]*=[[:space:]]*"[^"$]+"' --include=build.gradle . 2>/dev/null \
-                  | grep -oE '"[^"]+"' | tr -d '"' | head -1)
-          fi
-          if [ -z "$VER" ]; then
-            echo "::warning::Could not resolve a literal pomVersion; skipping tag/release."
-            exit 0
-          fi
-          echo "Resolved published version: $VER"
-
-          # Idempotent: skip if a Release for this version already exists (re-run / unchanged version).
-          if gh release view "$VER" >/dev/null 2>&1; then
-            echo "Release $VER already exists; nothing to do."
-            exit 0
-          fi
-
-          # -RC / any suffixed version is a pre-release so it doesn't take the "Latest release" badge.
-          PRERELEASE=""
-          case "$VER" in *-*) PRERELEASE="--prerelease";; esac
-
-          # Creates the tag ($VER) at this commit AND the Release in one call (needs contents: write).
-          # No local git identity required — the ref is created server-side via the API.
-          gh release create "$VER" --target "$GITHUB_SHA" --title "$VER" --generate-notes $PRERELEASE \
-            || echo "::warning::Failed to create tag/Release $VER (Actions token is likely read-only; set the repo/org default workflow permissions to read-and-write)."


### PR DESCRIPTION
## Urgent — unblocks all widget publishing

#847 set the shared `widget-publish.yml` to `permissions: contents: write`. Because a reusable workflow can't request more than the **caller** grants, and the widget repos' callers run at `contents: read` (a repo-level override that sits below the org default), the workflow became **invalid at validation time** — every widget publish failed with:

> The nested job 'publish' is requesting 'contents: write', but is only allowed 'contents: read'.

This reverts the shared workflow to its **exact pre-#847 state** (`contents: read`, tag/Release step removed), restoring publishing everywhere. Byte-identical to commit `25ec9c7`.

**Not draft** — this is an urgent unblock; merge as soon as reviewed.

## What about tagging / Releases?
Deferred, not abandoned. It will return in a follow-up that does **not** depend on `GITHUB_TOKEN: write` (a dedicated fine-grained PAT / GitHub App token), so it can never hard-break publishing again regardless of any repo's permission setting. Tracked on OP-17652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)