### PR TITLE
OP-17371 [Android][Config] Bump version.foundation to 5.5.76

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.75"
+version.foundation = "5.5.76"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.49-RC2"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
## Why
Companion to [endiosOneFoundation-Android#922](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/922), which adds `OnePreviewTheme` for themed offline Compose `@Preview` rendering. This points the LATEST development Foundation at that artifact.

## What
`version.foundation` 5.5.75 → **5.5.76**. Single-line change, no other version touched.

## ⚠️ Version note
[Android-Config#845](https://github.com/endiosGmbH/Android-Config/pull/845) (OP-17477, via Foundation [#946](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/946)) **also claims 5.5.76** and is ahead in the queue — #946 is review-ready while #922 is still a draft. Per convention the first to merge keeps 5.5.76 and whoever is behind re-bumps, so if #845/#946 land first this PR and #922 both move to **5.5.77**. Both sides change the same line to the same value, so no textual conflict either way.

## Merge order
1. [endiosOneFoundation-Android#922](https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/922) — `pomVersion` → 5.5.76 (must be merged **and published** first)
2. Android-Config#<this PR> — `version.foundation` → 5.5.76 — **This PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)