### PR TITLE
AGENCY-7272 Bump Foundation to 5.5.77

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.76"
+version.foundation = "5.5.77"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.49-RC2"
 version.foundation_auth = "5.0.59"

--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.75"
+version.foundation = "5.5.76"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.49-RC2"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
## Summary
- Companion to https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/947 — bumps `version.foundation` so `oneWidgetContracts-Android` picks up the SUBSCRIPTION_RIGHT fallback label fix ("Nutzungsrecht" → "Bezugsrecht") on its next build.
- Originally targeted 5.5.76, but OP-17371's companion PR (#849) merged first and took that version — re-bumped to 5.5.77 to match Foundation PR #947's resolved version.

## Companion PRs
- endiosOneFoundation-Android: https://github.com/endiosGmbH/endiosOneFoundation-Android/pull/947

## Test plan
- [ ] Foundation PR merges and publishes 5.5.77 first