### PR TITLE
OP-17415 Bump foundation version to 5.5.78

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -51,7 +51,7 @@ version.firebase_crashlytics = "18.2.11"
 version.firebase_crashlytics_gradle = "2.9.0"
 version.firebase_messaging = "23.0.7"
 // foundation - LATEST development version
-version.foundation = "5.5.77"
+version.foundation = "5.5.78"
 // foundation - STABLE release version (used by release/* branches)
 version.foundation_release = "5.5.49-RC2"
 version.foundation_auth = "5.0.59"


### PR DESCRIPTION
## Summary

- Bumps `version.foundation` (LATEST) 5.5.77 → 5.5.78.

## Companion PRs

- endiosGmbH/endiosOneFoundation-Android#948 — `showDialog()` wedged by a dialog abandoned with its Activity

## Test plan

Version-only change; verified by the Foundation PR's unit tests and device QA.